### PR TITLE
Add resource validation layer for graphics API

### DIFF
--- a/sources/Directory.Packages.props
+++ b/sources/Directory.Packages.props
@@ -7,7 +7,7 @@
     <ItemGroup>
         <PackageVersion Include="Hexa.NET.ImGui" Version="2.2.7" />
         <PackageVersion Include="Roslynator.Analyzers" Version="4.13.1" />
-        <PackageVersion Include="Slangc.NET" Version="2025.11.0" />
+        <PackageVersion Include="Slangc.NET" Version="2025.12.0" />
     </ItemGroup>
 
 </Project>

--- a/sources/Zenith.NET/Buffer.cs
+++ b/sources/Zenith.NET/Buffer.cs
@@ -13,7 +13,7 @@ public abstract class Buffer(GraphicsContext context, BufferDesc desc) : Graphic
         CommandBuffer commandBuffer = Context.Copy.CommandBuffer();
 
         commandBuffer.Begin();
-        commandBuffer.UpdateBuffer(data, this, offsetInBytes);
+        commandBuffer.UploadBuffer(data, this, offsetInBytes);
         commandBuffer.End();
         commandBuffer.Submit();
 

--- a/sources/Zenith.NET/Buffer.cs
+++ b/sources/Zenith.NET/Buffer.cs
@@ -10,11 +10,6 @@ public abstract class Buffer(GraphicsContext context, BufferDesc desc) : Graphic
 
     public void Upload<T>(ReadOnlySpan<T> data, uint offsetInBytes)
     {
-        if (Context.UseDebugLayer)
-        {
-            throw new NotImplementedException("Buffer upload validation is not implemented yet.");
-        }
-
         CommandBuffer commandBuffer = Context.Copy.CommandBuffer();
 
         commandBuffer.Begin();

--- a/sources/Zenith.NET/BufferView.cs
+++ b/sources/Zenith.NET/BufferView.cs
@@ -6,7 +6,7 @@ public abstract class BufferView(GraphicsContext context, BufferViewDesc desc) :
 
     public ref readonly BufferViewDesc Desc => ref desc;
 
-    public abstract nint Pointer { get; }
+    public nint Pointer { get; } = desc.Buffer.Pointer is not 0 ? (nint)(desc.Buffer.Pointer + desc.OffsetInBytes) : 0;
 
     public void Upload<T>(ReadOnlySpan<T> data, uint offsetInBytes)
     {

--- a/sources/Zenith.NET/BufferView.cs
+++ b/sources/Zenith.NET/BufferView.cs
@@ -10,11 +10,6 @@ public abstract class BufferView(GraphicsContext context, BufferViewDesc desc) :
 
     public void Upload<T>(ReadOnlySpan<T> data, uint offsetInBytes)
     {
-        if (Context.UseDebugLayer)
-        {
-            throw new NotImplementedException("Buffer subresource upload validation is not implemented yet.");
-        }
-
         Desc.Buffer.Upload(data, Desc.OffsetInBytes + offsetInBytes);
     }
 }

--- a/sources/Zenith.NET/CommandBuffer.cs
+++ b/sources/Zenith.NET/CommandBuffer.cs
@@ -120,22 +120,16 @@ public abstract class CommandBuffer(GraphicsContext context, CommandQueue queue)
 
     public BottomLevelAccelerationStructure BuildAccelerationStructure(BottomLevelAccelerationStructureDesc desc)
     {
-        if (Context.UseDebugLayer)
-        {
-            throw new NotImplementedException("Acceleration structure validation is not implemented yet.");
-        }
-
-        return BuildAccelerationStructureImpl(desc);
+        return Context.UseDebugLayer
+            ? throw new NotImplementedException("Acceleration structure validation is not implemented yet.")
+            : BuildAccelerationStructureImpl(desc);
     }
 
     public TopLevelAccelerationStructure BuildAccelerationStructure(TopLevelAccelerationStructureDesc desc)
     {
-        if (Context.UseDebugLayer)
-        {
-            throw new NotImplementedException("Acceleration structure validation is not implemented yet.");
-        }
-
-        return BuildAccelerationStructureImpl(desc);
+        return Context.UseDebugLayer
+            ? throw new NotImplementedException("Acceleration structure validation is not implemented yet.")
+            : BuildAccelerationStructureImpl(desc);
     }
 
     public void UpdateAccelerationStructure(TopLevelAccelerationStructure accelerationStructure, TopLevelAccelerationStructureDesc newDesc)

--- a/sources/Zenith.NET/CommandBuffer.cs
+++ b/sources/Zenith.NET/CommandBuffer.cs
@@ -212,34 +212,24 @@ public abstract class CommandBuffer(GraphicsContext context, CommandQueue queue)
         SetRayTracingPipelineImpl(pipeline);
     }
 
-    public void SetVertexBuffer(uint slot, IBuffer buffer, uint offset)
+    public void SetVertexBuffer(uint slot, IBuffer buffer, uint offsetInBytes)
     {
         if (Context.UseDebugLayer)
         {
             throw new NotImplementedException("Vertex buffer validation is not implemented yet.");
         }
 
-        SetVertexBufferImpl(slot, buffer, offset);
+        SetVertexBufferImpl(slot, buffer, offsetInBytes);
     }
 
-    public void SetVertexBuffers(IBuffer[] buffers, uint[] offsets)
-    {
-        if (Context.UseDebugLayer)
-        {
-            throw new NotImplementedException("Vertex buffers validation is not implemented yet.");
-        }
-
-        SetVertexBuffersImpl(buffers, offsets);
-    }
-
-    public void SetIndexBuffer(IBuffer buffer, IndexFormat format, uint offset)
+    public void SetIndexBuffer(IndexFormat format, IBuffer buffer, uint offsetInBytes)
     {
         if (Context.UseDebugLayer)
         {
             throw new NotImplementedException("Index buffer validation is not implemented yet.");
         }
 
-        SetIndexBufferImpl(buffer, format, offset);
+        SetIndexBufferImpl(format, buffer, offsetInBytes);
     }
 
     public void PrepareResourceSets(ResourceSet[] sets)
@@ -272,14 +262,14 @@ public abstract class CommandBuffer(GraphicsContext context, CommandQueue queue)
         DrawImpl(vertexCount, instanceCount, firstVertex, firstInstance);
     }
 
-    public void DrawIndirect(IBuffer argBuffer, uint offset, uint drawCount)
+    public void DrawIndirect(IBuffer indirectBuffer, uint offsetInBytes, uint drawCount)
     {
         if (Context.UseDebugLayer)
         {
             throw new NotImplementedException("Indirect draw validation is not implemented yet.");
         }
 
-        DrawIndirectImpl(argBuffer, offset, drawCount);
+        DrawIndirectImpl(indirectBuffer, offsetInBytes, drawCount);
     }
 
     public void DrawIndexed(uint indexCount, uint instanceCount, uint firstIndex, int vertexOffset, uint firstInstance)
@@ -292,14 +282,14 @@ public abstract class CommandBuffer(GraphicsContext context, CommandQueue queue)
         DrawIndexedImpl(indexCount, instanceCount, firstIndex, vertexOffset, firstInstance);
     }
 
-    public void DrawIndexedIndirect(IBuffer argBuffer, uint offset, uint drawCount)
+    public void DrawIndexedIndirect(IBuffer indirectBuffer, uint offsetInBytes, uint drawCount)
     {
         if (Context.UseDebugLayer)
         {
             throw new NotImplementedException("Indirect indexed draw validation is not implemented yet.");
         }
 
-        DrawIndexedIndirectImpl(argBuffer, offset, drawCount);
+        DrawIndexedIndirectImpl(indirectBuffer, offsetInBytes, drawCount);
     }
 
     public void Dispatch(uint groupCountX, uint groupCountY, uint groupCountZ)
@@ -312,14 +302,14 @@ public abstract class CommandBuffer(GraphicsContext context, CommandQueue queue)
         DispatchImpl(groupCountX, groupCountY, groupCountZ);
     }
 
-    public void DispatchIndirect(IBuffer argBuffer, uint offset)
+    public void DispatchIndirect(IBuffer indirectBuffer, uint offsetInBytes)
     {
         if (Context.UseDebugLayer)
         {
             throw new NotImplementedException("Indirect dispatch validation is not implemented yet.");
         }
 
-        DispatchIndirectImpl(argBuffer, offset);
+        DispatchIndirectImpl(indirectBuffer, offsetInBytes);
     }
 
     public void DispatchRays(uint width, uint height, uint depth)
@@ -401,11 +391,9 @@ public abstract class CommandBuffer(GraphicsContext context, CommandQueue queue)
 
     protected abstract void SetRayTracingPipelineImpl(RayTracingPipeline pipeline);
 
-    protected abstract void SetVertexBufferImpl(uint slot, IBuffer buffer, uint offset);
+    protected abstract void SetVertexBufferImpl(uint slot, IBuffer buffer, uint offsetInBytes);
 
-    protected abstract void SetVertexBuffersImpl(IBuffer[] buffers, uint[] offsets);
-
-    protected abstract void SetIndexBufferImpl(IBuffer buffer, IndexFormat format, uint offset);
+    protected abstract void SetIndexBufferImpl(IndexFormat format, IBuffer buffer, uint offsetInBytes);
 
     protected abstract void PrepareResourceSetsImpl(ResourceSet[] sets);
 
@@ -413,15 +401,15 @@ public abstract class CommandBuffer(GraphicsContext context, CommandQueue queue)
 
     protected abstract void DrawImpl(uint vertexCount, uint instanceCount, uint firstVertex, uint firstInstance);
 
-    protected abstract void DrawIndirectImpl(IBuffer argBuffer, uint offset, uint drawCount);
+    protected abstract void DrawIndirectImpl(IBuffer indirectBuffer, uint offsetInBytes, uint drawCount);
 
     protected abstract void DrawIndexedImpl(uint indexCount, uint instanceCount, uint firstIndex, int vertexOffset, uint firstInstance);
 
-    protected abstract void DrawIndexedIndirectImpl(IBuffer argBuffer, uint offset, uint drawCount);
+    protected abstract void DrawIndexedIndirectImpl(IBuffer indirectBuffer, uint offsetInBytes, uint drawCount);
 
     protected abstract void DispatchImpl(uint groupCountX, uint groupCountY, uint groupCountZ);
 
-    protected abstract void DispatchIndirectImpl(IBuffer argBuffer, uint offset);
+    protected abstract void DispatchIndirectImpl(IBuffer indirectBuffer, uint offsetInBytes);
 
     protected abstract void DispatchRaysImpl(uint width, uint height, uint depth);
 

--- a/sources/Zenith.NET/CommandBuffer.cs
+++ b/sources/Zenith.NET/CommandBuffer.cs
@@ -48,7 +48,7 @@ public abstract class CommandBuffer(GraphicsContext context, CommandQueue queue)
         ResetImpl();
     }
 
-    public void UpdateBuffer<T>(ReadOnlySpan<T> data, IBuffer buffer, uint offsetInBytes)
+    public void UploadBuffer<T>(ReadOnlySpan<T> data, IBuffer buffer, uint offsetInBytes)
     {
         if (Context.UseDebugLayer)
         {
@@ -73,7 +73,7 @@ public abstract class CommandBuffer(GraphicsContext context, CommandQueue queue)
         CopyBufferImpl(src, srcOffsetInBytes, dest, destOffsetInBytes, sizeInBytes);
     }
 
-    public void UpdateTexture<T>(ReadOnlySpan<T> data, ITexture texture, TextureSlice slice, TextureOffset offset, TextureExtent extent)
+    public void UploadTexture<T>(ReadOnlySpan<T> data, ITexture texture, TextureSlice slice, TextureOffset offset, TextureExtent extent)
     {
         if (Context.UseDebugLayer)
         {
@@ -118,28 +118,28 @@ public abstract class CommandBuffer(GraphicsContext context, CommandQueue queue)
         ResolveTextureImpl(src, srcOffset, dest, destOffset);
     }
 
-    public BottomLevelAccelerationStructure BuildAccelerationStructure(BottomLevelAccelerationStructureDesc desc)
+    public BottomLevelAccelerationStructure BuildBottomLevelAccelerationStructure(BottomLevelAccelerationStructureDesc desc)
     {
         return Context.UseDebugLayer
             ? throw new NotImplementedException("Acceleration structure validation is not implemented yet.")
-            : BuildAccelerationStructureImpl(desc);
+            : BuildBottomLevelAccelerationStructureImpl(desc);
     }
 
-    public TopLevelAccelerationStructure BuildAccelerationStructure(TopLevelAccelerationStructureDesc desc)
+    public TopLevelAccelerationStructure BuildTopLevelAccelerationStructure(TopLevelAccelerationStructureDesc desc)
     {
         return Context.UseDebugLayer
             ? throw new NotImplementedException("Acceleration structure validation is not implemented yet.")
-            : BuildAccelerationStructureImpl(desc);
+            : BuildTopLevelAccelerationStructureImpl(desc);
     }
 
-    public void UpdateAccelerationStructure(TopLevelAccelerationStructure accelerationStructure, TopLevelAccelerationStructureDesc newDesc)
+    public void UpdateTopLevelAccelerationStructure(TopLevelAccelerationStructure accelerationStructure, TopLevelAccelerationStructureDesc newDesc)
     {
         if (Context.UseDebugLayer)
         {
             throw new NotImplementedException("Acceleration structure update validation is not implemented yet.");
         }
 
-        UpdateAccelerationStructureImpl(accelerationStructure, newDesc);
+        UpdateTopLevelAccelerationStructureImpl(accelerationStructure, newDesc);
     }
 
     public void BeginRendering(FrameBuffer frameBuffer, ClearValue clearValue)
@@ -212,24 +212,24 @@ public abstract class CommandBuffer(GraphicsContext context, CommandQueue queue)
         SetRayTracingPipelineImpl(pipeline);
     }
 
-    public void SetVertexBuffer(uint slot, IBuffer buffer, uint offsetInBytes)
+    public void SetVertexBuffer(IBuffer buffer, uint offsetInBytes, uint slot)
     {
         if (Context.UseDebugLayer)
         {
             throw new NotImplementedException("Vertex buffer validation is not implemented yet.");
         }
 
-        SetVertexBufferImpl(slot, buffer, offsetInBytes);
+        SetVertexBufferImpl(buffer, offsetInBytes, slot);
     }
 
-    public void SetIndexBuffer(IndexFormat format, IBuffer buffer, uint offsetInBytes)
+    public void SetIndexBuffer(IBuffer buffer, uint offsetInBytes, IndexFormat format)
     {
         if (Context.UseDebugLayer)
         {
             throw new NotImplementedException("Index buffer validation is not implemented yet.");
         }
 
-        SetIndexBufferImpl(format, buffer, offsetInBytes);
+        SetIndexBufferImpl(buffer, offsetInBytes, format);
     }
 
     public void PrepareResourceSets(ResourceSet[] sets)
@@ -242,14 +242,14 @@ public abstract class CommandBuffer(GraphicsContext context, CommandQueue queue)
         PrepareResourceSetsImpl(sets);
     }
 
-    public void BindResourceSet(uint slot, ResourceSet set)
+    public void BindResourceSet(ResourceSet set, uint slot)
     {
         if (Context.UseDebugLayer)
         {
             throw new NotImplementedException("Resource set validation is not implemented yet.");
         }
 
-        BindResourceSetImpl(slot, set);
+        BindResourceSetImpl(set, slot);
     }
 
     public void Draw(uint vertexCount, uint instanceCount, uint firstVertex, uint firstInstance)
@@ -371,11 +371,11 @@ public abstract class CommandBuffer(GraphicsContext context, CommandQueue queue)
 
     protected abstract void ResolveTextureImpl(ITexture src, TextureOffset srcOffset, ITexture dest, TextureOffset destOffset);
 
-    protected abstract BottomLevelAccelerationStructure BuildAccelerationStructureImpl(BottomLevelAccelerationStructureDesc desc);
+    protected abstract BottomLevelAccelerationStructure BuildBottomLevelAccelerationStructureImpl(BottomLevelAccelerationStructureDesc desc);
 
-    protected abstract TopLevelAccelerationStructure BuildAccelerationStructureImpl(TopLevelAccelerationStructureDesc desc);
+    protected abstract TopLevelAccelerationStructure BuildTopLevelAccelerationStructureImpl(TopLevelAccelerationStructureDesc desc);
 
-    protected abstract void UpdateAccelerationStructureImpl(TopLevelAccelerationStructure accelerationStructure, TopLevelAccelerationStructureDesc newDesc);
+    protected abstract void UpdateTopLevelAccelerationStructureImpl(TopLevelAccelerationStructure accelerationStructure, TopLevelAccelerationStructureDesc newDesc);
 
     protected abstract void BeginRenderingImpl(FrameBuffer frameBuffer, ClearValue clearValue);
 
@@ -391,13 +391,13 @@ public abstract class CommandBuffer(GraphicsContext context, CommandQueue queue)
 
     protected abstract void SetRayTracingPipelineImpl(RayTracingPipeline pipeline);
 
-    protected abstract void SetVertexBufferImpl(uint slot, IBuffer buffer, uint offsetInBytes);
+    protected abstract void SetVertexBufferImpl(IBuffer buffer, uint offsetInBytes, uint slot);
 
-    protected abstract void SetIndexBufferImpl(IndexFormat format, IBuffer buffer, uint offsetInBytes);
+    protected abstract void SetIndexBufferImpl(IBuffer buffer, uint offsetInBytes, IndexFormat format);
 
     protected abstract void PrepareResourceSetsImpl(ResourceSet[] sets);
 
-    protected abstract void BindResourceSetImpl(uint slot, ResourceSet set);
+    protected abstract void BindResourceSetImpl(ResourceSet set, uint slot);
 
     protected abstract void DrawImpl(uint vertexCount, uint instanceCount, uint firstVertex, uint firstInstance);
 

--- a/sources/Zenith.NET/CommandBuffer.cs
+++ b/sources/Zenith.NET/CommandBuffer.cs
@@ -6,30 +6,49 @@ public abstract class CommandBuffer(GraphicsContext context, CommandQueue queue)
 {
     protected CommandQueue Queue { get; } = queue;
 
-    #region State Management
-    public abstract void Begin();
+    public void Begin()
+    {
+        if (Context.UseDebugLayer)
+        {
+            throw new NotImplementedException("Command buffer validation is not implemented yet.");
+        }
 
-    public abstract void End();
+        BeginImpl();
+    }
+
+    public void End()
+    {
+        if (Context.UseDebugLayer)
+        {
+            throw new NotImplementedException("Command buffer validation is not implemented yet.");
+        }
+
+        EndImpl();
+    }
 
     public void Submit()
     {
+        if (Context.UseDebugLayer)
+        {
+            throw new NotImplementedException("Command buffer submission validation is not implemented yet.");
+        }
+
         Queue.Submit(this);
     }
 
     public void Reset()
     {
+        if (Context.UseDebugLayer)
+        {
+            throw new NotImplementedException("Command buffer reset validation is not implemented yet.");
+        }
+
         Context.Uploader.Release(this);
 
         ResetImpl();
     }
 
-    protected abstract void ResetImpl();
-    #endregion
-
-    #region Buffer Operations
-    public void UpdateBuffer<T>(ReadOnlySpan<T> data,
-                                IBuffer buffer,
-                                uint offsetInBytes)
+    public void UpdateBuffer<T>(ReadOnlySpan<T> data, IBuffer buffer, uint offsetInBytes)
     {
         if (Context.UseDebugLayer)
         {
@@ -41,22 +60,20 @@ public abstract class CommandBuffer(GraphicsContext context, CommandQueue queue)
         Buffer temporary = Context.Uploader.Buffer(this, sizeInBytes);
         temporary.Upload(data, 0);
 
-        CopyBuffer(temporary, 0, buffer, offsetInBytes, sizeInBytes);
+        CopyBufferImpl(temporary, 0, buffer, offsetInBytes, sizeInBytes);
     }
 
-    public abstract void CopyBuffer(IBuffer source,
-                                    uint sourceOffsetInBytes,
-                                    IBuffer destination,
-                                    uint destinationOffsetInBytes,
-                                    uint sizeInBytes);
-    #endregion
+    public void CopyBuffer(IBuffer src, uint srcOffsetInBytes, IBuffer dest, uint destOffsetInBytes, uint sizeInBytes)
+    {
+        if (Context.UseDebugLayer)
+        {
+            throw new NotImplementedException("Buffer copy validation is not implemented yet.");
+        }
 
-    #region Texture Operations
-    public void UpdateTexture<T>(ReadOnlySpan<T> data,
-                                 ITexture texture,
-                                 TextureSlice slice,
-                                 TextureOffset offset,
-                                 TextureExtent extent)
+        CopyBufferImpl(src, srcOffsetInBytes, dest, destOffsetInBytes, sizeInBytes);
+    }
+
+    public void UpdateTexture<T>(ReadOnlySpan<T> data, ITexture texture, TextureSlice slice, TextureOffset offset, TextureExtent extent)
     {
         if (Context.UseDebugLayer)
         {
@@ -68,102 +85,355 @@ public abstract class CommandBuffer(GraphicsContext context, CommandQueue queue)
         Buffer temporary = Context.Uploader.Buffer(this, sizeInBytes);
         temporary.Upload(data, 0);
 
-        CopyTexture(temporary, 0, sizeInBytes, texture, slice, offset, extent);
+        CopyTextureImpl(temporary, 0, sizeInBytes, texture, slice, offset, extent);
     }
 
-    public abstract void CopyTexture(IBuffer buffer,
-                                     uint offsetInBytes,
-                                     uint sizeInBytes,
-                                     ITexture texture,
-                                     TextureSlice slice,
-                                     TextureOffset offset,
-                                     TextureExtent extent);
+    public void CopyTexture(IBuffer buffer, uint offsetInBytes, uint sizeInBytes, ITexture texture, TextureSlice slice, TextureOffset offset, TextureExtent extent)
+    {
+        if (Context.UseDebugLayer)
+        {
+            throw new NotImplementedException("Texture copy validation is not implemented yet.");
+        }
 
-    public abstract void CopyTexture(ITexture source,
-                                     TextureOffset sourceOffset,
-                                     ITexture destination,
-                                     TextureOffset destinationOffset,
-                                     TextureExtent extent);
+        CopyTextureImpl(buffer, offsetInBytes, sizeInBytes, texture, slice, offset, extent);
+    }
 
-    public abstract void ResolveTexture(ITexture source,
-                                        TextureOffset sourceOffset,
-                                        ITexture destination,
-                                        TextureOffset destinationOffset);
-    #endregion
+    public void CopyTexture(ITexture src, TextureOffset srcOffset, ITexture dest, TextureOffset destOffset, TextureExtent extent)
+    {
+        if (Context.UseDebugLayer)
+        {
+            throw new NotImplementedException("Texture copy validation is not implemented yet.");
+        }
 
-    #region Acceleration Structure Operations
-    public abstract BottomLevelAccelerationStructure BuildAccelerationStructure(BottomLevelAccelerationStructureDesc desc);
+        CopyTextureImpl(src, srcOffset, dest, destOffset, extent);
+    }
 
-    public abstract TopLevelAccelerationStructure BuildAccelerationStructure(TopLevelAccelerationStructureDesc desc);
+    public void ResolveTexture(ITexture src, TextureOffset srcOffset, ITexture dest, TextureOffset destOffset)
+    {
+        if (Context.UseDebugLayer)
+        {
+            throw new NotImplementedException("Texture resolve validation is not implemented yet.");
+        }
 
-    public abstract void UpdateAccelerationStructure(TopLevelAccelerationStructure accelerationStructure,
-                                                     TopLevelAccelerationStructureDesc newDesc);
-    #endregion
+        ResolveTextureImpl(src, srcOffset, dest, destOffset);
+    }
 
-    #region Rendering Operations
-    public abstract void BeginRendering(FrameBuffer frameBuffer, ClearValue clearValue);
+    public BottomLevelAccelerationStructure BuildAccelerationStructure(BottomLevelAccelerationStructureDesc desc)
+    {
+        if (Context.UseDebugLayer)
+        {
+            throw new NotImplementedException("Acceleration structure validation is not implemented yet.");
+        }
 
-    public abstract void EndRendering();
+        return BuildAccelerationStructureImpl(desc);
+    }
 
-    public abstract void SetScissors(Scissor[] scissors);
+    public TopLevelAccelerationStructure BuildAccelerationStructure(TopLevelAccelerationStructureDesc desc)
+    {
+        if (Context.UseDebugLayer)
+        {
+            throw new NotImplementedException("Acceleration structure validation is not implemented yet.");
+        }
 
-    public abstract void SetViewports(Viewport[] viewports);
-    #endregion
+        return BuildAccelerationStructureImpl(desc);
+    }
 
-    #region Pipeline Operations
-    public abstract void SetGraphicsPipeline(GraphicsPipeline pipeline);
+    public void UpdateAccelerationStructure(TopLevelAccelerationStructure accelerationStructure, TopLevelAccelerationStructureDesc newDesc)
+    {
+        if (Context.UseDebugLayer)
+        {
+            throw new NotImplementedException("Acceleration structure update validation is not implemented yet.");
+        }
 
-    public abstract void SetComputePipeline(ComputePipeline pipeline);
+        UpdateAccelerationStructureImpl(accelerationStructure, newDesc);
+    }
 
-    public abstract void SetRayTracingPipeline(RayTracingPipeline pipeline);
-    #endregion
+    public void BeginRendering(FrameBuffer frameBuffer, ClearValue clearValue)
+    {
+        if (Context.UseDebugLayer)
+        {
+            throw new NotImplementedException("Rendering validation is not implemented yet.");
+        }
 
-    #region Resource Binding Operations
-    public abstract void PrepareResources(ResourceSet[] resourceSets);
+        BeginRenderingImpl(frameBuffer, clearValue);
+    }
 
-    public abstract void SetVertexBuffer(uint slot, Buffer buffer, uint offset = 0);
+    public void EndRendering()
+    {
+        if (Context.UseDebugLayer)
+        {
+            throw new NotImplementedException("Rendering validation is not implemented yet.");
+        }
 
-    public abstract void SetVertexBuffers(Buffer[] buffers, uint[] offsets);
+        EndRenderingImpl();
+    }
 
-    public abstract void SetIndexBuffer(Buffer buffer, IndexFormat format = IndexFormat.UInt16, uint offset = 0);
+    public void SetScissors(Scissor[] scissors)
+    {
+        if (Context.UseDebugLayer)
+        {
+            throw new NotImplementedException("Scissor validation is not implemented yet.");
+        }
 
-    public abstract void SetResourceSet(uint slot, ResourceSet resourceSet);
-    #endregion
+        SetScissorsImpl(scissors);
+    }
 
-    #region Drawing Operations
-    public abstract void Draw(uint vertexCount, uint instanceCount, uint firstVertex = 0, uint firstInstance = 0);
+    public void SetViewports(Viewport[] viewports)
+    {
+        if (Context.UseDebugLayer)
+        {
+            throw new NotImplementedException("Viewport validation is not implemented yet.");
+        }
 
-    public abstract void DrawIndirect(Buffer argBuffer, uint offset, uint drawCount);
+        SetViewportsImpl(viewports);
+    }
 
-    public abstract void DrawIndexed(uint indexCount,
-                                     uint instanceCount,
-                                     uint firstIndex = 0,
-                                     int vertexOffset = 0,
-                                     uint firstInstance = 0);
+    public void SetGraphicsPipeline(GraphicsPipeline pipeline)
+    {
+        if (Context.UseDebugLayer)
+        {
+            throw new NotImplementedException("Graphics pipeline validation is not implemented yet.");
+        }
 
-    public abstract void DrawIndexedIndirect(Buffer argBuffer, uint offset, uint drawCount);
-    #endregion
+        SetGraphicsPipelineImpl(pipeline);
+    }
 
-    #region Compute Operations
-    public abstract void Dispatch(uint groupCountX, uint groupCountY, uint groupCountZ);
+    public void SetComputePipeline(ComputePipeline pipeline)
+    {
+        if (Context.UseDebugLayer)
+        {
+            throw new NotImplementedException("Compute pipeline validation is not implemented yet.");
+        }
 
-    public abstract void DispatchIndirect(Buffer argBuffer, uint offset);
-    #endregion
+        SetComputePipelineImpl(pipeline);
+    }
 
-    #region Ray Tracing Operations
-    public abstract void DispatchRays(uint width, uint height, uint depth);
-    #endregion
+    public void SetRayTracingPipeline(RayTracingPipeline pipeline)
+    {
+        if (Context.UseDebugLayer)
+        {
+            throw new NotImplementedException("Ray tracing pipeline validation is not implemented yet.");
+        }
 
-    #region Debugging
-    public abstract void BeginDebugEvent(string label);
+        SetRayTracingPipelineImpl(pipeline);
+    }
 
-    public abstract void EndDebugEvent();
+    public void SetVertexBuffer(uint slot, IBuffer buffer, uint offset)
+    {
+        if (Context.UseDebugLayer)
+        {
+            throw new NotImplementedException("Vertex buffer validation is not implemented yet.");
+        }
 
-    public abstract void InsertDebugMarker(string label);
-    #endregion
+        SetVertexBufferImpl(slot, buffer, offset);
+    }
+
+    public void SetVertexBuffers(IBuffer[] buffers, uint[] offsets)
+    {
+        if (Context.UseDebugLayer)
+        {
+            throw new NotImplementedException("Vertex buffers validation is not implemented yet.");
+        }
+
+        SetVertexBuffersImpl(buffers, offsets);
+    }
+
+    public void SetIndexBuffer(IBuffer buffer, IndexFormat format, uint offset)
+    {
+        if (Context.UseDebugLayer)
+        {
+            throw new NotImplementedException("Index buffer validation is not implemented yet.");
+        }
+
+        SetIndexBufferImpl(buffer, format, offset);
+    }
+
+    public void PrepareResourceSets(ResourceSet[] sets)
+    {
+        if (Context.UseDebugLayer)
+        {
+            throw new NotImplementedException("Resource set preparation validation is not implemented yet.");
+        }
+
+        PrepareResourceSetsImpl(sets);
+    }
+
+    public void BindResourceSet(uint slot, ResourceSet set)
+    {
+        if (Context.UseDebugLayer)
+        {
+            throw new NotImplementedException("Resource set validation is not implemented yet.");
+        }
+
+        BindResourceSetImpl(slot, set);
+    }
+
+    public void Draw(uint vertexCount, uint instanceCount, uint firstVertex, uint firstInstance)
+    {
+        if (Context.UseDebugLayer)
+        {
+            throw new NotImplementedException("Draw validation is not implemented yet.");
+        }
+
+        DrawImpl(vertexCount, instanceCount, firstVertex, firstInstance);
+    }
+
+    public void DrawIndirect(IBuffer argBuffer, uint offset, uint drawCount)
+    {
+        if (Context.UseDebugLayer)
+        {
+            throw new NotImplementedException("Indirect draw validation is not implemented yet.");
+        }
+
+        DrawIndirectImpl(argBuffer, offset, drawCount);
+    }
+
+    public void DrawIndexed(uint indexCount, uint instanceCount, uint firstIndex, int vertexOffset, uint firstInstance)
+    {
+        if (Context.UseDebugLayer)
+        {
+            throw new NotImplementedException("Indexed draw validation is not implemented yet.");
+        }
+
+        DrawIndexedImpl(indexCount, instanceCount, firstIndex, vertexOffset, firstInstance);
+    }
+
+    public void DrawIndexedIndirect(IBuffer argBuffer, uint offset, uint drawCount)
+    {
+        if (Context.UseDebugLayer)
+        {
+            throw new NotImplementedException("Indirect indexed draw validation is not implemented yet.");
+        }
+
+        DrawIndexedIndirectImpl(argBuffer, offset, drawCount);
+    }
+
+    public void Dispatch(uint groupCountX, uint groupCountY, uint groupCountZ)
+    {
+        if (Context.UseDebugLayer)
+        {
+            throw new NotImplementedException("Dispatch validation is not implemented yet.");
+        }
+
+        DispatchImpl(groupCountX, groupCountY, groupCountZ);
+    }
+
+    public void DispatchIndirect(IBuffer argBuffer, uint offset)
+    {
+        if (Context.UseDebugLayer)
+        {
+            throw new NotImplementedException("Indirect dispatch validation is not implemented yet.");
+        }
+
+        DispatchIndirectImpl(argBuffer, offset);
+    }
+
+    public void DispatchRays(uint width, uint height, uint depth)
+    {
+        if (Context.UseDebugLayer)
+        {
+            throw new NotImplementedException("Ray dispatch validation is not implemented yet.");
+        }
+
+        DispatchRaysImpl(width, height, depth);
+    }
+
+    public void BeginDebugEvent(string label)
+    {
+        if (Context.UseDebugLayer)
+        {
+            throw new NotImplementedException("Debug event validation is not implemented yet.");
+        }
+
+        BeginDebugEventImpl(label);
+    }
+
+    public void EndDebugEvent()
+    {
+        if (Context.UseDebugLayer)
+        {
+            throw new NotImplementedException("Debug event validation is not implemented yet.");
+        }
+
+        EndDebugEventImpl();
+    }
+
+    public void InsertDebugMarker(string label)
+    {
+        if (Context.UseDebugLayer)
+        {
+            throw new NotImplementedException("Debug marker validation is not implemented yet.");
+        }
+
+        InsertDebugMarkerImpl(label);
+    }
 
     protected override void Destroy()
     {
         Context.Uploader.Release(this);
     }
+
+    protected abstract void BeginImpl();
+
+    protected abstract void EndImpl();
+
+    protected abstract void ResetImpl();
+
+    protected abstract void CopyBufferImpl(IBuffer src, uint srcOffsetInBytes, IBuffer dest, uint destOffsetInBytes, uint sizeInBytes);
+
+    protected abstract void CopyTextureImpl(IBuffer buffer, uint offsetInBytes, uint sizeInBytes, ITexture texture, TextureSlice slice, TextureOffset offset, TextureExtent extent);
+
+    protected abstract void CopyTextureImpl(ITexture src, TextureOffset srcOffset, ITexture dest, TextureOffset destOffset, TextureExtent extent);
+
+    protected abstract void ResolveTextureImpl(ITexture src, TextureOffset srcOffset, ITexture dest, TextureOffset destOffset);
+
+    protected abstract BottomLevelAccelerationStructure BuildAccelerationStructureImpl(BottomLevelAccelerationStructureDesc desc);
+
+    protected abstract TopLevelAccelerationStructure BuildAccelerationStructureImpl(TopLevelAccelerationStructureDesc desc);
+
+    protected abstract void UpdateAccelerationStructureImpl(TopLevelAccelerationStructure accelerationStructure, TopLevelAccelerationStructureDesc newDesc);
+
+    protected abstract void BeginRenderingImpl(FrameBuffer frameBuffer, ClearValue clearValue);
+
+    protected abstract void EndRenderingImpl();
+
+    protected abstract void SetScissorsImpl(Scissor[] scissors);
+
+    protected abstract void SetViewportsImpl(Viewport[] viewports);
+
+    protected abstract void SetGraphicsPipelineImpl(GraphicsPipeline pipeline);
+
+    protected abstract void SetComputePipelineImpl(ComputePipeline pipeline);
+
+    protected abstract void SetRayTracingPipelineImpl(RayTracingPipeline pipeline);
+
+    protected abstract void SetVertexBufferImpl(uint slot, IBuffer buffer, uint offset);
+
+    protected abstract void SetVertexBuffersImpl(IBuffer[] buffers, uint[] offsets);
+
+    protected abstract void SetIndexBufferImpl(IBuffer buffer, IndexFormat format, uint offset);
+
+    protected abstract void PrepareResourceSetsImpl(ResourceSet[] sets);
+
+    protected abstract void BindResourceSetImpl(uint slot, ResourceSet set);
+
+    protected abstract void DrawImpl(uint vertexCount, uint instanceCount, uint firstVertex, uint firstInstance);
+
+    protected abstract void DrawIndirectImpl(IBuffer argBuffer, uint offset, uint drawCount);
+
+    protected abstract void DrawIndexedImpl(uint indexCount, uint instanceCount, uint firstIndex, int vertexOffset, uint firstInstance);
+
+    protected abstract void DrawIndexedIndirectImpl(IBuffer argBuffer, uint offset, uint drawCount);
+
+    protected abstract void DispatchImpl(uint groupCountX, uint groupCountY, uint groupCountZ);
+
+    protected abstract void DispatchIndirectImpl(IBuffer argBuffer, uint offset);
+
+    protected abstract void DispatchRaysImpl(uint width, uint height, uint depth);
+
+    protected abstract void BeginDebugEventImpl(string label);
+
+    protected abstract void EndDebugEventImpl();
+
+    protected abstract void InsertDebugMarkerImpl(string label);
 }

--- a/sources/Zenith.NET/Enums/Blend.cs
+++ b/sources/Zenith.NET/Enums/Blend.cs
@@ -6,21 +6,21 @@ public enum Blend
 
     One,
 
-    SourceAlpha,
+    SrcAlpha,
 
-    InverseSourceAlpha,
+    InverseSrcAlpha,
 
-    DestinationAlpha,
+    DestAlpha,
 
-    InverseDestinationAlpha,
+    InverseDestAlpha,
 
-    SourceColor,
+    SrcColor,
 
-    InverseSourceColor,
+    InverseSrcColor,
 
-    DestinationColor,
+    DestColor,
 
-    InverseDestinationColor,
+    InverseDestColor,
 
     BlendFactor,
 

--- a/sources/Zenith.NET/Enums/BufferUsageFlags.cs
+++ b/sources/Zenith.NET/Enums/BufferUsageFlags.cs
@@ -5,19 +5,19 @@ public enum BufferUsageFlags
 {
     None = 0,
 
-    VertexBuffer = 1 << 0,
+    Vertex = 1 << 0,
 
-    IndexBuffer = 1 << 1,
+    Index = 1 << 1,
 
-    IndirectBuffer = 1 << 2,
+    Indirect = 1 << 2,
 
-    ConstantBuffer = 1 << 3,
+    AccelerationStructure = 1 << 3,
 
-    StructuredBuffer = 1 << 4,
+    Constant = 1 << 4,
 
-    RWStructuredBuffer = 1 << 5,
+    ShaderResource = 1 << 5,
 
-    AccelerationStructure = 1 << 6,
+    UnorderedAccess = 1 << 6,
 
     Dynamic = 1 << 7
 }

--- a/sources/Zenith.NET/Enums/BufferUsageFlags.cs
+++ b/sources/Zenith.NET/Enums/BufferUsageFlags.cs
@@ -9,15 +9,15 @@ public enum BufferUsageFlags
 
     IndexBuffer = 1 << 1,
 
-    ConstantBuffer = 1 << 2,
+    IndirectBuffer = 1 << 2,
 
-    ShaderResource = 1 << 3,
+    ConstantBuffer = 1 << 3,
 
-    UnorderedAccess = 1 << 4,
+    AccelerationStructure = 1 << 4,
 
-    AccelerationStructure = 1 << 5,
+    ShaderReadOnly = 1 << 5,
 
-    IndirectBuffer = 1 << 6,
+    ShaderReadWrite = 1 << 6,
 
     Dynamic = 1 << 7
 }

--- a/sources/Zenith.NET/Enums/BufferUsageFlags.cs
+++ b/sources/Zenith.NET/Enums/BufferUsageFlags.cs
@@ -13,11 +13,11 @@ public enum BufferUsageFlags
 
     ConstantBuffer = 1 << 3,
 
-    AccelerationStructure = 1 << 4,
+    StructuredBuffer = 1 << 4,
 
-    ShaderReadOnly = 1 << 5,
+    RWStructuredBuffer = 1 << 5,
 
-    ShaderReadWrite = 1 << 6,
+    AccelerationStructure = 1 << 6,
 
     Dynamic = 1 << 7
 }

--- a/sources/Zenith.NET/Enums/ElementSemantic.cs
+++ b/sources/Zenith.NET/Enums/ElementSemantic.cs
@@ -1,6 +1,6 @@
 ﻿namespace Zenith.NET;
 
-public enum ElementSemanticType
+public enum ElementSemantic
 {
     Position,
 

--- a/sources/Zenith.NET/Enums/TextureUsageFlags.cs
+++ b/sources/Zenith.NET/Enums/TextureUsageFlags.cs
@@ -9,7 +9,7 @@ public enum TextureUsageFlags
 
     DepthStencil = 1 << 1,
 
-    ShaderReadOnly = 1 << 2,
+    ShaderResource = 1 << 2,
 
-    ShaderReadWrite = 1 << 3
+    UnorderedAccess = 1 << 3
 }

--- a/sources/Zenith.NET/Enums/TextureUsageFlags.cs
+++ b/sources/Zenith.NET/Enums/TextureUsageFlags.cs
@@ -5,11 +5,11 @@ public enum TextureUsageFlags
 {
     None = 0,
 
-    ShaderResource = 1 << 0,
+    RenderTarget = 1 << 0,
 
-    UnorderedAccess = 1 << 1,
+    DepthStencil = 1 << 1,
 
-    RenderTarget = 1 << 2,
+    ShaderReadOnly = 1 << 2,
 
-    DepthStencil = 1 << 3
+    ShaderReadWrite = 1 << 3
 }

--- a/sources/Zenith.NET/GraphicsContext.cs
+++ b/sources/Zenith.NET/GraphicsContext.cs
@@ -19,6 +19,7 @@ public abstract class GraphicsContext : DisposableObject
         Compute = compute;
         Copy = copy;
         Uploader = new(this);
+        Validator = new(this);
     }
 
     public Backend Backend { get; }
@@ -36,6 +37,8 @@ public abstract class GraphicsContext : DisposableObject
     public CommandQueue Copy { get; }
 
     internal Uploader Uploader { get; }
+
+    internal ResourceValidator Validator { get; }
 
     public event EventHandler<DebugCallbackArgs>? DebugCallback;
 

--- a/sources/Zenith.NET/GraphicsContext.cs
+++ b/sources/Zenith.NET/GraphicsContext.cs
@@ -38,7 +38,7 @@ public abstract class GraphicsContext : DisposableObject
 
     internal Uploader Uploader { get; }
 
-    internal ResourceValidator Validator { get; }
+    internal Validator Validator { get; }
 
     public event EventHandler<DebugCallbackArgs>? DebugCallback;
 

--- a/sources/Zenith.NET/Interfaces/IBindableResource.cs
+++ b/sources/Zenith.NET/Interfaces/IBindableResource.cs
@@ -1,3 +1,3 @@
 ﻿namespace Zenith.NET;
 
-public interface IBindableResource;
+public interface IBindableResource : IDisposableObject;

--- a/sources/Zenith.NET/Interfaces/IBuffer.cs
+++ b/sources/Zenith.NET/Interfaces/IBuffer.cs
@@ -1,6 +1,6 @@
 ﻿namespace Zenith.NET;
 
-public interface IBuffer : IBindableResource, IDisposableObject
+public interface IBuffer : IBindableResource
 {
     nint Pointer { get; }
 

--- a/sources/Zenith.NET/Interfaces/ITexture.cs
+++ b/sources/Zenith.NET/Interfaces/ITexture.cs
@@ -1,6 +1,6 @@
 ﻿namespace Zenith.NET;
 
-public interface ITexture : IBindableResource, IDisposableObject
+public interface ITexture : IBindableResource
 {
     void Upload<T>(ReadOnlySpan<T> data, TextureSlice slice, TextureOffset offset, TextureExtent extent);
 }

--- a/sources/Zenith.NET/ResourceFactory.cs
+++ b/sources/Zenith.NET/ResourceFactory.cs
@@ -4,7 +4,7 @@ public abstract class ResourceFactory(GraphicsContext context)
 {
     public GraphicsContext Context { get; } = context;
 
-    internal Validator Validator { get; } = new(context);
+    internal ResourceValidator Validator { get; } = new(context);
 
     public SwapChain CreateSwapChain(SwapChainDesc desc)
     {

--- a/sources/Zenith.NET/ResourceFactory.cs
+++ b/sources/Zenith.NET/ResourceFactory.cs
@@ -100,6 +100,7 @@ public abstract class ResourceFactory(GraphicsContext context)
     {
         if (Context.UseDebugLayer)
         {
+            Validator.ValidateShaderDesc(desc);
         }
 
         return CreateShaderImpl(desc);

--- a/sources/Zenith.NET/ResourceFactory.cs
+++ b/sources/Zenith.NET/ResourceFactory.cs
@@ -110,6 +110,7 @@ public abstract class ResourceFactory(GraphicsContext context)
     {
         if (Context.UseDebugLayer)
         {
+            Validator.ValidateGraphicsPipelineDesc(desc);
         }
 
         return CreateGraphicsPipelineImpl(desc);
@@ -119,6 +120,7 @@ public abstract class ResourceFactory(GraphicsContext context)
     {
         if (Context.UseDebugLayer)
         {
+            Validator.ValidateComputePipelineDesc(desc);
         }
 
         return CreateComputePipelineImpl(desc);
@@ -128,6 +130,7 @@ public abstract class ResourceFactory(GraphicsContext context)
     {
         if (Context.UseDebugLayer)
         {
+            Validator.ValidateRayTracingPipelineDesc(desc);
         }
 
         return CreateRayTracingPipelineImpl(desc);

--- a/sources/Zenith.NET/ResourceFactory.cs
+++ b/sources/Zenith.NET/ResourceFactory.cs
@@ -40,6 +40,7 @@ public abstract class ResourceFactory(GraphicsContext context)
     {
         if (Context.UseDebugLayer)
         {
+            Validator.ValidateTextureDesc(desc);
         }
 
         return CreateTextureImpl(desc);
@@ -49,6 +50,7 @@ public abstract class ResourceFactory(GraphicsContext context)
     {
         if (Context.UseDebugLayer)
         {
+            Validator.ValidateTextureViewDesc(desc);
         }
 
         return CreateTextureViewImpl(desc);

--- a/sources/Zenith.NET/ResourceFactory.cs
+++ b/sources/Zenith.NET/ResourceFactory.cs
@@ -60,6 +60,7 @@ public abstract class ResourceFactory(GraphicsContext context)
     {
         if (Context.UseDebugLayer)
         {
+            Validator.ValidateSamplerDesc(desc);
         }
 
         return CreateSamplerImpl(desc);

--- a/sources/Zenith.NET/ResourceFactory.cs
+++ b/sources/Zenith.NET/ResourceFactory.cs
@@ -70,6 +70,7 @@ public abstract class ResourceFactory(GraphicsContext context)
     {
         if (Context.UseDebugLayer)
         {
+            Validator.ValidateResourceLayoutDesc(desc);
         }
 
         return CreateResourceLayoutImpl(desc);
@@ -79,6 +80,7 @@ public abstract class ResourceFactory(GraphicsContext context)
     {
         if (Context.UseDebugLayer)
         {
+            Validator.ValidateResourceSetDesc(desc);
         }
 
         return CreateResourceSetImpl(desc);

--- a/sources/Zenith.NET/ResourceFactory.cs
+++ b/sources/Zenith.NET/ResourceFactory.cs
@@ -90,6 +90,7 @@ public abstract class ResourceFactory(GraphicsContext context)
     {
         if (Context.UseDebugLayer)
         {
+            Validator.ValidateFrameBufferDesc(desc);
         }
 
         return CreateFrameBufferImpl(desc);

--- a/sources/Zenith.NET/ResourceFactory.cs
+++ b/sources/Zenith.NET/ResourceFactory.cs
@@ -4,13 +4,11 @@ public abstract class ResourceFactory(GraphicsContext context)
 {
     public GraphicsContext Context { get; } = context;
 
-    internal ResourceValidator Validator { get; } = new(context);
-
     public SwapChain CreateSwapChain(SwapChainDesc desc)
     {
         if (Context.UseDebugLayer)
         {
-            Validator.ValidateSwapChainDesc(desc);
+            Context.Validator.ValidateSwapChainDesc(desc);
         }
 
         return CreateSwapChainImpl(desc);
@@ -20,7 +18,7 @@ public abstract class ResourceFactory(GraphicsContext context)
     {
         if (Context.UseDebugLayer)
         {
-            Validator.ValidateBufferDesc(desc);
+            Context.Validator.ValidateBufferDesc(desc);
         }
 
         return CreateBufferImpl(desc);
@@ -30,7 +28,7 @@ public abstract class ResourceFactory(GraphicsContext context)
     {
         if (Context.UseDebugLayer)
         {
-            Validator.ValidateBufferViewDesc(desc);
+            Context.Validator.ValidateBufferViewDesc(desc);
         }
 
         return CreateBufferViewImpl(desc);
@@ -40,7 +38,7 @@ public abstract class ResourceFactory(GraphicsContext context)
     {
         if (Context.UseDebugLayer)
         {
-            Validator.ValidateTextureDesc(desc);
+            Context.Validator.ValidateTextureDesc(desc);
         }
 
         return CreateTextureImpl(desc);
@@ -50,7 +48,7 @@ public abstract class ResourceFactory(GraphicsContext context)
     {
         if (Context.UseDebugLayer)
         {
-            Validator.ValidateTextureViewDesc(desc);
+            Context.Validator.ValidateTextureViewDesc(desc);
         }
 
         return CreateTextureViewImpl(desc);
@@ -60,7 +58,7 @@ public abstract class ResourceFactory(GraphicsContext context)
     {
         if (Context.UseDebugLayer)
         {
-            Validator.ValidateSamplerDesc(desc);
+            Context.Validator.ValidateSamplerDesc(desc);
         }
 
         return CreateSamplerImpl(desc);
@@ -70,7 +68,7 @@ public abstract class ResourceFactory(GraphicsContext context)
     {
         if (Context.UseDebugLayer)
         {
-            Validator.ValidateResourceLayoutDesc(desc);
+            Context.Validator.ValidateResourceLayoutDesc(desc);
         }
 
         return CreateResourceLayoutImpl(desc);
@@ -80,7 +78,7 @@ public abstract class ResourceFactory(GraphicsContext context)
     {
         if (Context.UseDebugLayer)
         {
-            Validator.ValidateResourceSetDesc(desc);
+            Context.Validator.ValidateResourceSetDesc(desc);
         }
 
         return CreateResourceSetImpl(desc);
@@ -90,7 +88,7 @@ public abstract class ResourceFactory(GraphicsContext context)
     {
         if (Context.UseDebugLayer)
         {
-            Validator.ValidateFrameBufferDesc(desc);
+            Context.Validator.ValidateFrameBufferDesc(desc);
         }
 
         return CreateFrameBufferImpl(desc);
@@ -100,7 +98,7 @@ public abstract class ResourceFactory(GraphicsContext context)
     {
         if (Context.UseDebugLayer)
         {
-            Validator.ValidateShaderDesc(desc);
+            Context.Validator.ValidateShaderDesc(desc);
         }
 
         return CreateShaderImpl(desc);
@@ -110,7 +108,7 @@ public abstract class ResourceFactory(GraphicsContext context)
     {
         if (Context.UseDebugLayer)
         {
-            Validator.ValidateGraphicsPipelineDesc(desc);
+            Context.Validator.ValidateGraphicsPipelineDesc(desc);
         }
 
         return CreateGraphicsPipelineImpl(desc);
@@ -120,7 +118,7 @@ public abstract class ResourceFactory(GraphicsContext context)
     {
         if (Context.UseDebugLayer)
         {
-            Validator.ValidateComputePipelineDesc(desc);
+            Context.Validator.ValidateComputePipelineDesc(desc);
         }
 
         return CreateComputePipelineImpl(desc);
@@ -130,7 +128,7 @@ public abstract class ResourceFactory(GraphicsContext context)
     {
         if (Context.UseDebugLayer)
         {
-            Validator.ValidateRayTracingPipelineDesc(desc);
+            Context.Validator.ValidateRayTracingPipelineDesc(desc);
         }
 
         return CreateRayTracingPipelineImpl(desc);

--- a/sources/Zenith.NET/ResourceFactory.cs
+++ b/sources/Zenith.NET/ResourceFactory.cs
@@ -4,10 +4,13 @@ public abstract class ResourceFactory(GraphicsContext context)
 {
     public GraphicsContext Context { get; } = context;
 
+    internal Validator Validator { get; } = new(context);
+
     public SwapChain CreateSwapChain(SwapChainDesc desc)
     {
         if (Context.UseDebugLayer)
         {
+            Validator.ValidateSwapChainDesc(desc);
         }
 
         return CreateSwapChainImpl(desc);

--- a/sources/Zenith.NET/ResourceFactory.cs
+++ b/sources/Zenith.NET/ResourceFactory.cs
@@ -20,6 +20,7 @@ public abstract class ResourceFactory(GraphicsContext context)
     {
         if (Context.UseDebugLayer)
         {
+            Validator.ValidateBufferDesc(desc);
         }
 
         return CreateBufferImpl(desc);
@@ -29,6 +30,7 @@ public abstract class ResourceFactory(GraphicsContext context)
     {
         if (Context.UseDebugLayer)
         {
+            Validator.ValidateBufferViewDesc(desc);
         }
 
         return CreateBufferViewImpl(desc);

--- a/sources/Zenith.NET/ResourceValidator.cs
+++ b/sources/Zenith.NET/ResourceValidator.cs
@@ -98,9 +98,16 @@ internal class ResourceValidator(GraphicsContext context)
             context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Texture width and height must be equal and greater than zero for cube textures.");
         }
 
-        if (desc.Layers is 0)
+        if (desc.Type is TextureType.Texture1DArray or TextureType.Texture2DArray or TextureType.TextureCubeArray)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Texture layers must be greater than zero.");
+            if (desc.Layers is 0)
+            {
+                context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Texture layers must be greater than zero.");
+            }
+        }
+        else if (desc.Layers is not 1)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Texture layers must be 1 for non-array textures.");
         }
 
         if (desc.MipLevels is 0)
@@ -398,15 +405,18 @@ internal class ResourceValidator(GraphicsContext context)
             return;
         }
 
-        ValidateTextureSlice(attachment.Target, attachment.Slice);
+        ObtainTextureValues(attachment.Target, out TextureType type, out uint layers, out uint mipLevels);
+
+        if (type is not TextureType.Texture2D or TextureType.Texture2DArray)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid texture type for frame buffer attachment: {type}. Only Texture2D and Texture2DArray are supported.");
+        }
+
+        ValidateTextureSlice(type, layers, mipLevels, attachment.Slice);
     }
 
-    private void ValidateTextureSlice(ITexture iTexture, TextureSlice slice)
+    private void ObtainTextureValues(ITexture iTexture, out TextureType type, out uint layers, out uint mipLevels)
     {
-        TextureType type;
-        uint layers;
-        uint mipLevels;
-
         if (iTexture is Texture texture)
         {
             type = texture.Desc.Type;
@@ -421,11 +431,16 @@ internal class ResourceValidator(GraphicsContext context)
         }
         else
         {
+            type = default;
+            layers = default;
+            mipLevels = default;
+
             context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Invalid texture type for slice validation. Expected Texture or TextureView.");
-
-            return;
         }
+    }
 
+    private void ValidateTextureSlice(TextureType type, uint layers, uint mipLevels, TextureSlice slice)
+    {
         if (type is TextureType.TextureCube or TextureType.TextureCubeArray)
         {
             if (slice.Face >= 6)

--- a/sources/Zenith.NET/ResourceValidator.cs
+++ b/sources/Zenith.NET/ResourceValidator.cs
@@ -76,10 +76,9 @@ internal class ResourceValidator(GraphicsContext context)
 
     public void ValidateTextureDesc(TextureDesc desc)
     {
-        if (!Enum.IsDefined(desc.Type))
-        {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid texture type: {desc.Type}. Supported types are: {string.Join(", ", Enum.GetNames<TextureType>())}.");
-        }
+        ValidateDefinedEnum(desc.Type, "texture type");
+
+        ValidateDefinedEnum(desc.Format, "texture format");
 
         if (desc.Type is TextureType.Texture1D or TextureType.Texture1DArray && desc.Width is 0)
         {
@@ -115,10 +114,7 @@ internal class ResourceValidator(GraphicsContext context)
             context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Texture mip levels must be greater than zero.");
         }
 
-        if (!Enum.IsDefined(desc.SampleCount))
-        {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid sample count: {desc.SampleCount}. Supported sample counts are: {string.Join(", ", Enum.GetNames<SampleCount>())}.");
-        }
+        ValidateDefinedEnum(desc.SampleCount, "sample count");
     }
 
     public void ValidateTextureViewDesc(TextureViewDesc desc)
@@ -161,30 +157,15 @@ internal class ResourceValidator(GraphicsContext context)
 
     public void ValidateSamplerDesc(SamplerDesc desc)
     {
-        if (!Enum.IsDefined(desc.U))
-        {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid U address mode: {desc.U}. Supported modes are: {string.Join(", ", Enum.GetNames<AddressMode>())}.");
-        }
+        ValidateDefinedEnum(desc.U, "U address mode");
 
-        if (!Enum.IsDefined(desc.V))
-        {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid V address mode: {desc.V}. Supported modes are: {string.Join(", ", Enum.GetNames<AddressMode>())}.");
-        }
+        ValidateDefinedEnum(desc.V, "V address mode");
 
-        if (!Enum.IsDefined(desc.W))
-        {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid W address mode: {desc.W}. Supported modes are: {string.Join(", ", Enum.GetNames<AddressMode>())}.");
-        }
+        ValidateDefinedEnum(desc.W, "W address mode");
 
-        if (!Enum.IsDefined(desc.Filter))
-        {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid filter: {desc.Filter}. Supported filters are: {string.Join(", ", Enum.GetNames<Filter>())}.");
-        }
+        ValidateDefinedEnum(desc.Filter, "filter");
 
-        if (!Enum.IsDefined(desc.ComparisonFunc))
-        {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid comparison function: {desc.ComparisonFunc}. Supported functions are: {string.Join(", ", Enum.GetNames<ComparisonFunc>())}.");
-        }
+        ValidateDefinedEnum(desc.ComparisonFunc, "comparison function");
 
         if (desc.MaxAnisotropy is not 1 and not 2 and not 4 and not 8 and not 16)
         {
@@ -206,10 +187,7 @@ internal class ResourceValidator(GraphicsContext context)
             context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "LodBias must be between -16 and 16.");
         }
 
-        if (!Enum.IsDefined(desc.BorderColor))
-        {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid border color: {desc.BorderColor}. Supported colors are: {string.Join(", ", Enum.GetNames<BorderColor>())}.");
-        }
+        ValidateDefinedEnum(desc.BorderColor, "border color");
     }
 
     public void ValidateResourceLayoutDesc(ResourceLayoutDesc desc)
@@ -230,10 +208,7 @@ internal class ResourceValidator(GraphicsContext context)
         {
             ResourceElement element = desc.Elements[i];
 
-            if (!Enum.IsDefined(element.Type))
-            {
-                context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid resource element type at index {i}: {element.Type}. Supported types are: {string.Join(", ", Enum.GetNames<ResourceType>())}.");
-            }
+            ValidateDefinedEnum(element.Type, $"resource element type at index {i}");
 
             if (element.Count is 0)
             {
@@ -365,18 +340,27 @@ internal class ResourceValidator(GraphicsContext context)
             context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Shader entry point must not be null or empty.");
         }
 
-        if (!Enum.IsDefined(desc.Stage))
-        {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid shader stage: {desc.Stage}. Supported stages are: {string.Join(", ", Enum.GetNames<ShaderStageFlags>())}.");
-        }
+        ValidateDefinedEnum(desc.Stage, "shader stage");
+    }
+
+    public void ValidateGraphicsPipelineDesc(GraphicsPipelineDesc desc)
+    {
+        ValidateRenderStates(desc.RenderStates);
+    }
+
+    public void ValidateComputePipelineDesc(ComputePipelineDesc desc)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void ValidateRayTracingPipelineDesc(RayTracingPipelineDesc desc)
+    {
+        throw new NotImplementedException();
     }
 
     private void ValidateSurface(Surface surface)
     {
-        if (!Enum.IsDefined(surface.Type))
-        {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid surface type: {surface.Type}. Supported types are: {string.Join(", ", Enum.GetNames<SurfaceType>())}.");
-        }
+        ValidateDefinedEnum(surface.Type, "surface type");
 
         if (surface.Handles is null)
         {
@@ -440,6 +424,55 @@ internal class ResourceValidator(GraphicsContext context)
         ValidateTextureSlice(type, layers, mipLevels, attachment.Slice);
     }
 
+    #region Graphics Pipeline Validation
+    private void ValidateRenderStates(RenderStates renderStates)
+    {
+        // RasterizerState
+        {
+            RasterizerState rasterizerState = renderStates.RasterizerState;
+
+            ValidateDefinedEnum(rasterizerState.CullMode, "cull mode");
+
+            ValidateDefinedEnum(rasterizerState.FillMode, "fill mode");
+
+            ValidateDefinedEnum(rasterizerState.FrontFace, "front face");
+
+            if (rasterizerState.DepthBias < 0)
+            {
+                context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Depth bias must be greater than or equal to zero.");
+            }
+
+            if (rasterizerState.DepthBiasClamp < 0)
+            {
+                context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Depth bias clamp must be greater than or equal to zero.");
+            }
+
+            if (rasterizerState.SlopeScaledDepthBias < 0)
+            {
+                context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Slope scaled depth bias must be greater than or equal to zero.");
+            }
+        }
+
+        // DepthStencilState
+        {
+            DepthStencilState depthStencilState = renderStates.DepthStencilState;
+
+            ValidateDefinedEnum(depthStencilState.DepthFunc, "depth function");
+        }
+    }
+    #endregion
+
+    #region Universal Validation
+    private void ValidateDefinedEnum<TEnum>(TEnum value, string name) where TEnum : struct, Enum
+    {
+        if (!Enum.IsDefined(value))
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid {name}: {value}. Supported values are: {string.Join(", ", Enum.GetNames<TEnum>())}.");
+        }
+    }
+    #endregion
+
+    #region Universal Texture Validation
     private void ObtainTextureValues(ITexture iTexture, out TextureType type, out uint layers, out uint mipLevels)
     {
         if (iTexture is Texture texture)
@@ -495,4 +528,5 @@ internal class ResourceValidator(GraphicsContext context)
             context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid mip level: {slice.MipLevel}. It must be less than the number of mip levels ({mipLevels}).");
         }
     }
+    #endregion
 }

--- a/sources/Zenith.NET/ResourceValidator.cs
+++ b/sources/Zenith.NET/ResourceValidator.cs
@@ -317,14 +317,14 @@ internal class ResourceValidator(GraphicsContext context)
             context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Frame buffer cannot have more than 8 color targets.");
         }
 
-        foreach (FrameBufferAttachment frameBufferAttachment in desc.ColorTargets)
+        for (int i = 0; i < desc.ColorTargets.Length; i++)
         {
-            ValidateFrameBufferAttachment(frameBufferAttachment);
+            ValidateFrameBufferAttachment(desc.ColorTargets[i], $"color target at index {i}");
         }
 
         if (desc.DepthStencilTarget is not null)
         {
-            ValidateFrameBufferAttachment(desc.DepthStencilTarget.Value);
+            ValidateFrameBufferAttachment(desc.DepthStencilTarget.Value, "depth-stencil target");
         }
     }
 
@@ -388,18 +388,20 @@ internal class ResourceValidator(GraphicsContext context)
 
                 ValidateDefinedEnum(depthStencilState.DepthFunc, "depth function");
 
-                ValidateDepthStencilStateOp(depthStencilState.FrontFace);
+                ValidateDepthStencilStateOp(depthStencilState.FrontFace, "front face");
 
-                ValidateDepthStencilStateOp(depthStencilState.BackFace);
+                ValidateDepthStencilStateOp(depthStencilState.BackFace, "back face");
             }
 
             // BlendState
             {
                 BlendState blendState = renderStates.BlendState;
 
-                foreach (BlendStateRenderTarget renderTarget in (BlendStateRenderTarget[])(blendState.IndependentBlendEnable ? [blendState.RenderTarget0, blendState.RenderTarget1, blendState.RenderTarget2, blendState.RenderTarget3, blendState.RenderTarget4, blendState.RenderTarget5, blendState.RenderTarget6, blendState.RenderTarget7] : [blendState.RenderTarget0]))
+                BlendStateRenderTarget[] renderTargets = blendState.IndependentBlendEnable ? [blendState.RenderTarget0, blendState.RenderTarget1, blendState.RenderTarget2, blendState.RenderTarget3, blendState.RenderTarget4, blendState.RenderTarget5, blendState.RenderTarget6, blendState.RenderTarget7] : [blendState.RenderTarget0];
+
+                for (int i = 0; i < renderTargets.Length; i++)
                 {
-                    ValidateBlendStateRenderTarget(renderTarget);
+                    ValidateBlendStateRenderTarget(renderTargets[i], $"render target at index {i}");
                 }
             }
         }
@@ -408,30 +410,24 @@ internal class ResourceValidator(GraphicsContext context)
         {
             GraphicsShaders shaders = desc.Shaders;
 
-            if (shaders.Vertex?.IsDisposed is not false)
+            ValidateShader(shaders.Vertex, "Vertex shader");
+
+            if (shaders.Hull is not null)
             {
-                context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Vertex shader must reference a valid shader that is not disposed.");
+                ValidateShader(shaders.Hull, "Hull shader");
             }
 
-            if (shaders.Hull?.IsDisposed is true)
+            if (shaders.Domain is not null)
             {
-                context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Hull shader must reference a valid shader that is not disposed.");
+                ValidateShader(shaders.Domain, "Domain shader");
             }
 
-            if (shaders.Domain?.IsDisposed is true)
+            if (shaders.Geometry is not null)
             {
-                context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Domain shader must reference a valid shader that is not disposed.");
+                ValidateShader(shaders.Geometry, "Geometry shader");
             }
 
-            if (shaders.Geometry?.IsDisposed is true)
-            {
-                context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Geometry shader must reference a valid shader that is not disposed.");
-            }
-
-            if (shaders.Pixel?.IsDisposed is not false)
-            {
-                context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Pixel shader must reference a valid shader that is not disposed.");
-            }
+            ValidateShader(shaders.Pixel, "Pixel shader");
         }
 
         if (desc.InputLayouts is null || desc.InputLayouts.Length is 0)
@@ -439,10 +435,7 @@ internal class ResourceValidator(GraphicsContext context)
             context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Graphics pipeline must have at least one input layout.");
         }
 
-        if (desc.ResourceLayouts is null)
-        {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Graphics pipeline resource layouts cannot be null.");
-        }
+        ValidateResourceLayouts(desc.ResourceLayouts);
 
         ValidateOutput(desc.Outputs);
     }
@@ -454,15 +447,68 @@ internal class ResourceValidator(GraphicsContext context)
             context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Compute pipeline must reference a valid shader that is not disposed.");
         }
 
-        if (desc.ResourceLayouts is null)
-        {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Compute pipeline resource layouts cannot be null.");
-        }
+        ValidateResourceLayouts(desc.ResourceLayouts);
     }
 
     public void ValidateRayTracingPipelineDesc(RayTracingPipelineDesc desc)
     {
-        throw new NotImplementedException();
+        // Shaders
+        {
+            RayTracingShaders shaders = desc.Shaders;
+
+            ValidateShader(shaders.RayGeneration, "Ray generation shader");
+
+            ValidateShaders(shaders.Miss, "Miss shaders");
+
+            ValidateShaders(shaders.AnyHit, "Any-hit shaders");
+
+            ValidateShaders(shaders.Intersection, "Intersection shaders");
+
+            ValidateShaders(shaders.ClosestHit, "Closest-hit shaders");
+        }
+
+        if (desc.HitGroups is null)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Ray tracing pipeline hit groups cannot be null.");
+        }
+        else
+        {
+            for (int i = 0; i < desc.HitGroups.Length; i++)
+            {
+                HitGroup hitGroup = desc.HitGroups[i];
+
+                ValidateDefinedEnum(hitGroup.Type, $"hit group type at index {i}");
+
+                if (string.IsNullOrEmpty(hitGroup.Name))
+                {
+                    context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Hit group at index {i} must have a non-empty name.");
+                }
+            }
+
+            string[] hitGroupNames = [.. desc.HitGroups.Select(static item => item.Name)];
+
+            if (hitGroupNames.Distinct().Count() != hitGroupNames.Length)
+            {
+                context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Ray tracing pipeline hit groups must have unique names. Duplicate names found.");
+            }
+        }
+
+        ValidateResourceLayouts(desc.ResourceLayouts);
+
+        if (desc.MaxTraceRecursionDepth > 31)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Max trace recursion depth must be less than or equal to 31.");
+        }
+
+        if (desc.MaxPayloadSizeInBytes % 4 is not 0)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Max payload size in bytes must be a multiple of 4.");
+        }
+
+        if (desc.MaxAttributeSizeInBytes % 4 is not 0 or > 32)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Max attribute size in bytes must be a multiple of 4 and less than or equal to 32.");
+        }
     }
 
     private void ValidateSurface(Surface surface)
@@ -512,49 +558,84 @@ internal class ResourceValidator(GraphicsContext context)
         }
     }
 
-    private void ValidateFrameBufferAttachment(FrameBufferAttachment attachment)
+    private void ValidateFrameBufferAttachment(FrameBufferAttachment attachment, string name)
     {
         if (attachment.Target?.IsDisposed is not false)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Frame buffer attachment must reference a valid texture that is not disposed.");
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Attachment '{name}' is invalid. It must reference a valid texture that is not disposed.");
 
             return;
         }
 
-        ObtainTextureValues(attachment.Target, out TextureType type, out uint layers, out uint mipLevels);
+        ObtainTextureValues(attachment.Target, name, out TextureType type, out uint layers, out uint mipLevels);
 
         if (type is not TextureType.Texture2D or TextureType.Texture2DArray)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid texture type for frame buffer attachment: {type}. Only Texture2D and Texture2DArray are supported.");
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid texture type for frame buffer attachment '{name}': {type}. Only Texture2D and Texture2DArray are supported.");
         }
 
-        ValidateTextureSlice(type, layers, mipLevels, attachment.Slice);
+        ValidateTextureSlice(type, layers, mipLevels, attachment.Slice, name);
     }
 
-    private void ValidateDepthStencilStateOp(DepthStencilStateOp stateOp)
+    private void ValidateDepthStencilStateOp(DepthStencilStateOp stateOp, string name)
     {
-        ValidateDefinedEnum(stateOp.StencilFailOp, "stencil fail operation");
+        ValidateDefinedEnum(stateOp.StencilFailOp, $"{name} stencil fail operation");
 
-        ValidateDefinedEnum(stateOp.StencilDepthFailOp, "stencil depth fail operation");
+        ValidateDefinedEnum(stateOp.StencilDepthFailOp, $"{name} stencil depth fail operation");
 
-        ValidateDefinedEnum(stateOp.StencilPassOp, "stencil pass operation");
+        ValidateDefinedEnum(stateOp.StencilPassOp, $"{name} stencil pass operation");
 
-        ValidateDefinedEnum(stateOp.StencilFunc, "stencil function");
+        ValidateDefinedEnum(stateOp.StencilFunc, $"{name} stencil function");
     }
 
-    private void ValidateBlendStateRenderTarget(BlendStateRenderTarget renderTarget)
+    private void ValidateBlendStateRenderTarget(BlendStateRenderTarget renderTarget, string name)
     {
-        ValidateDefinedEnum(renderTarget.SrcBlend, "source blend");
+        ValidateDefinedEnum(renderTarget.SrcBlend, $"{name} source blend");
 
-        ValidateDefinedEnum(renderTarget.DestBlend, "destination blend");
+        ValidateDefinedEnum(renderTarget.DestBlend, $"{name} destination blend");
 
-        ValidateDefinedEnum(renderTarget.BlendOp, "blend operation");
+        ValidateDefinedEnum(renderTarget.BlendOp, $"{name} blend operation");
 
-        ValidateDefinedEnum(renderTarget.SrcBlendAlpha, "source blend alpha");
+        ValidateDefinedEnum(renderTarget.SrcBlendAlpha, $"{name} source alpha blend");
 
-        ValidateDefinedEnum(renderTarget.DestBlendAlpha, "destination blend alpha");
+        ValidateDefinedEnum(renderTarget.DestBlendAlpha, $"{name} destination alpha blend");
 
-        ValidateDefinedEnum(renderTarget.BlendOpAlpha, "blend operation alpha");
+        ValidateDefinedEnum(renderTarget.BlendOpAlpha, $"{name} alpha blend operation");
+    }
+
+    private void ValidateShaders(Shader[]? shaders, string name)
+    {
+        if (shaders is null)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"{name} cannot be null.");
+
+            return;
+        }
+
+        for (int i = 0; i < shaders.Length; i++)
+        {
+            ValidateShader(shaders[i], $"{name} at index {i}");
+        }
+    }
+
+    private void ValidateResourceLayouts(ResourceLayout[]? resourceLayouts)
+    {
+        if (resourceLayouts is null)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Resource layouts cannot be null.");
+
+            return;
+        }
+
+        for (int i = 0; i < resourceLayouts.Length; i++)
+        {
+            ResourceLayout? resourceLayout = resourceLayouts[i];
+
+            if (resourceLayout?.IsDisposed is not false)
+            {
+                context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Resource layout at index {i} must reference a valid resource layout that is not disposed.");
+            }
+        }
     }
 
     private void ValidateOutput(Output output)
@@ -592,10 +673,18 @@ internal class ResourceValidator(GraphicsContext context)
             context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid {name}: {value}. Supported values are: {string.Join(", ", Enum.GetNames<TEnum>())}.");
         }
     }
+
+    private void ValidateShader(Shader? shader, string name)
+    {
+        if (shader?.IsDisposed is not false)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"{name} must reference a valid shader that is not disposed.");
+        }
+    }
     #endregion
 
     #region Universal Texture Validation
-    private void ObtainTextureValues(ITexture iTexture, out TextureType type, out uint layers, out uint mipLevels)
+    private void ObtainTextureValues(ITexture iTexture, string name, out TextureType type, out uint layers, out uint mipLevels)
     {
         if (iTexture is Texture texture)
         {
@@ -615,39 +704,39 @@ internal class ResourceValidator(GraphicsContext context)
             layers = default;
             mipLevels = default;
 
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Invalid texture type for slice validation. Expected Texture or TextureView.");
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid texture type for slice validation in {name}. Expected Texture or TextureView.");
         }
     }
 
-    private void ValidateTextureSlice(TextureType type, uint layers, uint mipLevels, TextureSlice slice)
+    private void ValidateTextureSlice(TextureType type, uint layers, uint mipLevels, TextureSlice slice, string name)
     {
         if (type is TextureType.TextureCube or TextureType.TextureCubeArray)
         {
             if (slice.Face >= 6)
             {
-                context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid face index: {slice.Face}. It must be between 0 and 5 for cube textures.");
+                context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid face index: {slice.Face} for {name} with texture type {type}. It must be less than 6.");
             }
         }
         else if (slice.Face is not 0)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid face index: {slice.Face}. It must be 0 for non-cube textures.");
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid face index: {slice.Face} for {name} with texture type {type}. Only TextureCube and TextureCubeArray support multiple faces.");
         }
 
         if (arrayTextureTypes.Contains(type))
         {
             if (slice.Layer >= layers)
             {
-                context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid layer index: {slice.Layer}. It must be less than the number of layers ({layers}) for array textures.");
+                context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid layer index: {slice.Layer} for {name} with texture type {type}. It must be less than the number of layers ({layers}).");
             }
         }
         else if (slice.Layer is not 0)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid layer index: {slice.Layer}. It must be 0 for non-array textures.");
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid layer index: {slice.Layer} for {name} with texture type {type}. Only array textures support multiple layers.");
         }
 
         if (slice.MipLevel >= mipLevels)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid mip level: {slice.MipLevel}. It must be less than the number of mip levels ({mipLevels}).");
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid mip level: {slice.MipLevel} for {name} with texture type {type}. It must be less than the number of mip levels ({mipLevels}).");
         }
     }
     #endregion

--- a/sources/Zenith.NET/ResourceValidator.cs
+++ b/sources/Zenith.NET/ResourceValidator.cs
@@ -17,6 +17,13 @@ internal class ResourceValidator(GraphicsContext context)
         PixelFormat.D32FloatS8UInt
     ];
 
+    private static readonly TextureType[] arrayTextureTypes =
+    [
+        TextureType.Texture1DArray,
+        TextureType.Texture2DArray,
+        TextureType.TextureCubeArray
+    ];
+
     public void ValidateSwapChainDesc(SwapChainDesc desc)
     {
         ValidateSurface(desc.Surface);
@@ -97,7 +104,7 @@ internal class ResourceValidator(GraphicsContext context)
             context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Texture width and height must be equal and greater than zero for cube textures.");
         }
 
-        if (desc.Type is TextureType.Texture1DArray or TextureType.Texture2DArray or TextureType.TextureCubeArray)
+        if (arrayTextureTypes.Contains(desc.Type))
         {
             if (desc.Layers is 0)
             {
@@ -618,7 +625,7 @@ internal class ResourceValidator(GraphicsContext context)
             context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid face index: {slice.Face}. It must be 0 for non-cube textures.");
         }
 
-        if (type is TextureType.Texture1DArray or TextureType.Texture2DArray or TextureType.TextureCubeArray)
+        if (arrayTextureTypes.Contains(type))
         {
             if (slice.Layer >= layers)
             {

--- a/sources/Zenith.NET/ResourceValidator.cs
+++ b/sources/Zenith.NET/ResourceValidator.cs
@@ -185,7 +185,7 @@ internal class ResourceValidator(GraphicsContext context)
             context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "MaxLod must be greater than or equal to MinLod.");
         }
 
-        if (desc.LodBias < -16 || desc.LodBias > 16)
+        if (desc.LodBias is < -16 or > 16)
         {
             context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "LodBias must be between -16 and 16.");
         }

--- a/sources/Zenith.NET/ResourceValidator.cs
+++ b/sources/Zenith.NET/ResourceValidator.cs
@@ -32,16 +32,14 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Invalid swap chain color target format '{desc.ColorTargetFormat}'. " +
-                                         $"Supported formats are: {string.Join(", ", swapChainFormats.Select(static item => item.ToString()))}.");
+                                         $"Color target format '{desc.ColorTargetFormat}' is not supported. Valid formats: {string.Join(", ", swapChainFormats.Select(static item => item.ToString()))}.");
         }
 
         if (desc.DepthStencilTargetFormat.HasValue && !depthStencilFormats.Contains(desc.DepthStencilTargetFormat.Value))
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Invalid swap chain depth-stencil target format '{desc.DepthStencilTargetFormat.Value}'. " +
-                                         $"Supported formats are: {string.Join(", ", depthStencilFormats.Select(static item => item.ToString()))}.");
+                                         $"Depth-stencil target format '{desc.DepthStencilTargetFormat.Value}' is not supported. Valid formats: {string.Join(", ", depthStencilFormats.Select(static item => item.ToString()))}.");
         }
     }
 
@@ -51,15 +49,14 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Buffer size must be greater than zero. A buffer with zero size cannot be created.");
+                                         "Buffer size must be greater than 0 bytes.");
         }
 
         if (desc.StrideInBytes is 0)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Warning,
-                                         "Buffer stride is zero. This may lead to unexpected behavior when using structured buffers. " +
-                                         "Consider setting a non-zero stride that matches your data structure size.");
+                                         "Buffer stride is 0 bytes. This may cause issues with structured buffers.");
         }
     }
 
@@ -69,8 +66,7 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Buffer view must reference a valid buffer that is not null and not disposed. " +
-                                         "Ensure the buffer exists and has not been disposed before creating the view.");
+                                         "Buffer view requires a valid, non-disposed buffer.");
 
             return;
         }
@@ -79,31 +75,27 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Buffer view offset ({desc.OffsetInBytes} bytes) must be less than the buffer's total size ({desc.Buffer.Desc.SizeInBytes} bytes). " +
-                                         $"Valid range is 0 to {desc.Buffer.Desc.SizeInBytes - 1}.");
+                                         $"Buffer view offset ({desc.OffsetInBytes} bytes) exceeds buffer size ({desc.Buffer.Desc.SizeInBytes} bytes).");
         }
 
         if (desc.SizeInBytes is 0)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Buffer view size must be greater than zero. A view with zero size cannot be created.");
+                                         "Buffer view size must be greater than 0 bytes.");
         }
         else if (desc.OffsetInBytes + desc.SizeInBytes > desc.Buffer.Desc.SizeInBytes)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Buffer view range exceeds buffer bounds. View range [{desc.OffsetInBytes}, {desc.OffsetInBytes + desc.SizeInBytes}) " +
-                                         $"exceeds buffer size ({desc.Buffer.Desc.SizeInBytes} bytes). " +
-                                         $"Ensure that OffsetInBytes + SizeInBytes ≤ {desc.Buffer.Desc.SizeInBytes}.");
+                                         $"Buffer view range [{desc.OffsetInBytes}, {desc.OffsetInBytes + desc.SizeInBytes}) exceeds buffer bounds [0, {desc.Buffer.Desc.SizeInBytes}).");
         }
 
         if (desc.StrideInBytes is 0)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Warning,
-                                         "Buffer view stride is zero. This may lead to unexpected behavior when using structured buffers. " +
-                                         "Consider setting a non-zero stride that matches your data structure size.");
+                                         "Buffer view stride is 0 bytes. This may cause issues with structured buffers.");
         }
     }
 
@@ -117,29 +109,25 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Texture width must be greater than zero for 1D textures. " +
-                                         "Specify a valid width for the texture dimensions.");
+                                         "1D texture width must be greater than 0.");
         }
         else if (desc.Type is TextureType.Texture2D or TextureType.Texture2DArray && (desc.Width is 0 || desc.Height is 0))
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Texture width ({desc.Width}) and height ({desc.Height}) must both be greater than zero for 2D textures. " +
-                                         "Specify valid dimensions for both width and height.");
+                                         "2D texture dimensions must be greater than 0.");
         }
         else if (desc.Type is TextureType.Texture3D && (desc.Width is 0 || desc.Height is 0 || desc.Depth is 0))
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Texture width ({desc.Width}), height ({desc.Height}), and depth ({desc.Depth}) must all be greater than zero for 3D textures. " +
-                                         "Specify valid dimensions for all three axes.");
+                                         "3D texture dimensions must be greater than 0.");
         }
         else if (desc.Type is TextureType.TextureCube or TextureType.TextureCubeArray && (desc.Width is 0 || desc.Height is 0 || desc.Width != desc.Height))
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Cube texture dimensions are invalid. Width ({desc.Width}) and height ({desc.Height}) must be equal and greater than zero. " +
-                                         "Cube textures require square faces.");
+                                         "Cube texture must have equal width and height greater than 0.");
         }
 
         if (arrayTextureTypes.Contains(desc.Type))
@@ -148,27 +136,24 @@ internal class ResourceValidator(GraphicsContext context)
             {
                 context.PublishDebugCallback(MessageCategory.System,
                                              MessageSeverity.Error,
-                                             $"Texture array layers must be greater than zero for {desc.Type}. " +
-                                             "Specify at least one layer for the texture array.");
+                                             "Array texture must have at least 1 layer.");
             }
         }
         else if (desc.Layers is not 1)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Non-array texture type '{desc.Type}' must have exactly 1 layer, but {desc.Layers} layers were specified. " +
-                                         "Set Layers to 1 for non-array textures.");
+                                         "Non-array texture must have exactly 1 layer.");
         }
 
         if (desc.MipLevels is 0)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Texture mip levels must be greater than zero. " +
-                                         "Specify at least 1 mip level (the base level) for the texture.");
+                                         "Texture must have at least 1 mip level.");
         }
 
-        ValidateDefinedEnum(desc.SampleCount, "texture sample count");
+        ValidateDefinedEnum(desc.SampleCount, "sample count");
     }
 
     public void ValidateTextureViewDesc(TextureViewDesc desc)
@@ -177,8 +162,7 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Texture view must reference a valid texture that is not null and not disposed. " +
-                                         "Ensure the texture exists and has not been disposed before creating the view.");
+                                         "Texture view requires a valid, non-disposed texture.");
 
             return;
         }
@@ -187,96 +171,84 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Texture view first layer index ({desc.FirstLayer}) must be less than the texture's total layer count ({desc.Texture.Desc.Layers}). " +
-                                         $"Valid range is 0 to {desc.Texture.Desc.Layers - 1}.");
+                                         $"Texture view first layer ({desc.FirstLayer}) exceeds texture layer count ({desc.Texture.Desc.Layers}).");
         }
 
         if (desc.LayerCount is 0)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Texture view layer count must be greater than zero. " +
-                                         "Specify at least one layer to include in the view.");
+                                         "Texture view must include at least 1 layer.");
         }
         else if (desc.FirstLayer + desc.LayerCount > desc.Texture.Desc.Layers)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Texture view layer range exceeds texture bounds. View range [{desc.FirstLayer}, {desc.FirstLayer + desc.LayerCount}) " +
-                                         $"exceeds texture layer count ({desc.Texture.Desc.Layers}). " +
-                                         $"Ensure that FirstLayer + LayerCount ≤ {desc.Texture.Desc.Layers}.");
+                                         $"Texture view layer range [{desc.FirstLayer}, {desc.FirstLayer + desc.LayerCount}) exceeds texture layer bounds [0, {desc.Texture.Desc.Layers}).");
         }
 
         if (desc.FirstMipLevel >= desc.Texture.Desc.MipLevels)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Texture view first mip level ({desc.FirstMipLevel}) must be less than the texture's total mip levels ({desc.Texture.Desc.MipLevels}). " +
-                                         $"Valid range is 0 to {desc.Texture.Desc.MipLevels - 1}.");
+                                         $"Texture view first mip level ({desc.FirstMipLevel}) exceeds texture mip level count ({desc.Texture.Desc.MipLevels}).");
         }
 
         if (desc.MipLevelCount is 0)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Texture view mip level count must be greater than zero. " +
-                                         "Specify at least one mip level to include in the view.");
+                                         "Texture view must include at least 1 mip level.");
         }
         else if (desc.FirstMipLevel + desc.MipLevelCount > desc.Texture.Desc.MipLevels)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Texture view mip level range exceeds texture bounds. View range [{desc.FirstMipLevel}, {desc.FirstMipLevel + desc.MipLevelCount}) " +
-                                         $"exceeds texture mip levels ({desc.Texture.Desc.MipLevels}). " +
-                                         $"Ensure that FirstMipLevel + MipLevelCount ≤ {desc.Texture.Desc.MipLevels}.");
+                                         $"Texture view mip level range [{desc.FirstMipLevel}, {desc.FirstMipLevel + desc.MipLevelCount}) exceeds texture mip level bounds [0, {desc.Texture.Desc.MipLevels}).");
         }
     }
 
     public void ValidateSamplerDesc(SamplerDesc desc)
     {
-        ValidateDefinedEnum(desc.U, "texture U (horizontal) address mode");
+        ValidateDefinedEnum(desc.U, "U address mode");
 
-        ValidateDefinedEnum(desc.V, "texture V (vertical) address mode");
+        ValidateDefinedEnum(desc.V, "V address mode");
 
-        ValidateDefinedEnum(desc.W, "texture W (depth) address mode");
+        ValidateDefinedEnum(desc.W, "W address mode");
 
-        ValidateDefinedEnum(desc.Filter, "texture filter mode");
+        ValidateDefinedEnum(desc.Filter, "filter");
 
-        ValidateDefinedEnum(desc.ComparisonFunc, "texture comparison function");
+        ValidateDefinedEnum(desc.ComparisonFunc, "comparison function");
 
         if (desc.MaxAnisotropy is not 1 and not 2 and not 4 and not 8 and not 16)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Invalid max anisotropy value '{desc.MaxAnisotropy}'. " +
-                                         "Supported values are: 1, 2, 4, 8, or 16. These values represent the maximum anisotropic filtering level.");
+                                         $"Max anisotropy must be 1, 2, 4, 8, or 16. Got: {desc.MaxAnisotropy}.");
         }
 
         if (desc.MinLod < 0)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Sampler MinLod ({desc.MinLod}) must be greater than or equal to zero. " +
-                                         "Negative LOD values are not supported.");
+                                         "Min LOD must be non-negative.");
         }
 
         if (desc.MaxLod < desc.MinLod)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Sampler MaxLod ({desc.MaxLod}) must be greater than or equal to MinLod ({desc.MinLod}). " +
-                                         "The LOD range must be valid with MaxLod ≥ MinLod.");
+                                         $"Max LOD ({desc.MaxLod}) must be greater than or equal to Min LOD ({desc.MinLod}).");
         }
 
         if (desc.LodBias is < -16 or > 16)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Sampler LodBias ({desc.LodBias}) must be within the range [-16, 16]. " +
-                                         "This range represents the maximum LOD bias supported by most hardware.");
+                                         $"LOD bias must be in range [-16, 16]. Got: {desc.LodBias}.");
         }
 
-        ValidateDefinedEnum(desc.BorderColor, "sampler border color");
+        ValidateDefinedEnum(desc.BorderColor, "border color");
     }
 
     public void ValidateResourceLayoutDesc(ResourceLayoutDesc desc)
@@ -285,8 +257,7 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Resource layout elements array cannot be null. " +
-                                         "Provide a valid array of resource elements, even if empty.");
+                                         "Resource layout elements cannot be null.");
 
             return;
         }
@@ -295,22 +266,20 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Resource layout must have at least one element. " +
-                                         "Define the resources that will be bound to this layout.");
+                                         "Resource layout must contain at least 1 element.");
         }
 
         for (int i = 0; i < desc.Elements.Length; i++)
         {
             ResourceElement element = desc.Elements[i];
 
-            ValidateDefinedEnum(element.Type, $"resource element type at binding index {i}");
+            ValidateDefinedEnum(element.Type, $"resource element type at index {i}");
 
             if (element.Count is 0)
             {
                 context.PublishDebugCallback(MessageCategory.System,
                                              MessageSeverity.Error,
-                                             $"Resource element at binding index {i} has a count of zero. " +
-                                             "Each element must have a count of at least 1 to represent valid resources.");
+                                             $"Resource element at index {i} must have count greater than 0.");
             }
         }
     }
@@ -321,8 +290,7 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Resource set must reference a valid resource layout that is not null and not disposed. " +
-                                         "Ensure the layout exists and has not been disposed before creating the resource set.");
+                                         "Resource set requires a valid, non-disposed resource layout.");
 
             return;
         }
@@ -331,8 +299,7 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Resource set resources array cannot be null. " +
-                                         "Provide a valid array of resources matching the layout requirements.");
+                                         "Resource set resources cannot be null.");
 
             return;
         }
@@ -343,8 +310,7 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Resource set has incorrect number of resources. Expected {types.Length} resources based on the layout, " +
-                                         $"but {desc.Resources.Length} were provided. The resource count must exactly match the layout definition.");
+                                         $"Resource set requires exactly {types.Length} resources to match layout. Got: {desc.Resources.Length}.");
 
             return;
         }
@@ -357,8 +323,7 @@ internal class ResourceValidator(GraphicsContext context)
             {
                 context.PublishDebugCallback(MessageCategory.System,
                                              MessageSeverity.Error,
-                                             $"Resource at binding slot {i} is null or disposed. " +
-                                             $"All resources must be valid, non-null, and not disposed. Expected resource type: {types[i]}.");
+                                             $"Resource at index {i} must be valid and non-disposed.");
 
                 continue;
             }
@@ -368,22 +333,20 @@ internal class ResourceValidator(GraphicsContext context)
                 case ResourceType.ConstantBuffer:
                 case ResourceType.StructuredBuffer:
                 case ResourceType.StructuredBufferReadWrite:
-                    if (resource is not Buffer and not BufferView)
+                    if (resource is not IBuffer)
                     {
                         context.PublishDebugCallback(MessageCategory.System,
                                                      MessageSeverity.Error,
-                                                     $"Resource at binding slot {i} is not a valid buffer resource. " +
-                                                     $"Expected Buffer or BufferView for resource type '{types[i]}', but got '{resource.GetType().Name}'.");
+                                                     $"Resource at index {i} must be a buffer for resource type '{types[i]}'.");
                     }
                     break;
                 case ResourceType.Texture:
                 case ResourceType.TextureReadWrite:
-                    if (resource is not Texture and not TextureView)
+                    if (resource is not ITexture)
                     {
                         context.PublishDebugCallback(MessageCategory.System,
                                                      MessageSeverity.Error,
-                                                     $"Resource at binding slot {i} is not a valid texture resource. " +
-                                                     $"Expected Texture or TextureView for resource type '{types[i]}', but got '{resource.GetType().Name}'.");
+                                                     $"Resource at index {i} must be a texture for resource type '{types[i]}'.");
                     }
                     break;
                 case ResourceType.Sampler:
@@ -391,8 +354,7 @@ internal class ResourceValidator(GraphicsContext context)
                     {
                         context.PublishDebugCallback(MessageCategory.System,
                                                      MessageSeverity.Error,
-                                                     $"Resource at binding slot {i} is not a valid sampler. " +
-                                                     $"Expected Sampler for resource type '{types[i]}', but got '{resource.GetType().Name}'.");
+                                                     $"Resource at index {i} must be a sampler for resource type '{types[i]}'.");
                     }
                     break;
                 case ResourceType.AccelerationStructure:
@@ -400,15 +362,13 @@ internal class ResourceValidator(GraphicsContext context)
                     {
                         context.PublishDebugCallback(MessageCategory.System,
                                                      MessageSeverity.Error,
-                                                     $"Resource at binding slot {i} is not a valid acceleration structure. " +
-                                                     $"Expected TopLevelAccelerationStructure for resource type '{types[i]}', but got '{resource.GetType().Name}'.");
+                                                     $"Resource at index {i} must be a top-level acceleration structure for resource type '{types[i]}'.");
                     }
                     break;
                 default:
                     context.PublishDebugCallback(MessageCategory.System,
                                                  MessageSeverity.Error,
-                                                 $"Unknown resource type '{types[i]}' at binding slot {i}. " +
-                                                 $"Supported resource types are: {string.Join(", ", Enum.GetNames<ResourceType>())}.");
+                                                 $"Resource type '{types[i]}' at index {i} is not recognized. Valid types: {string.Join(", ", Enum.GetNames<ResourceType>())}.");
                     break;
             }
         }
@@ -420,8 +380,7 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Frame buffer color targets array cannot be null. " +
-                                         "Provide a valid array of color targets, even if empty.");
+                                         "Frame buffer color targets cannot be null.");
 
             return;
         }
@@ -430,8 +389,7 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Frame buffer must have at least one render target. " +
-                                         "Provide either one or more color targets, or a depth-stencil target, or both.");
+                                         "Frame buffer must have at least 1 color target or a depth-stencil target.");
 
             return;
         }
@@ -440,13 +398,12 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Frame buffer has too many color targets ({desc.ColorTargets.Length}). " +
-                                         "Maximum supported color targets is 8. This is a hardware limitation on most GPUs.");
+                                         $"Frame buffer supports up to 8 color targets. Got: {desc.ColorTargets.Length}.");
         }
 
         for (int i = 0; i < desc.ColorTargets.Length; i++)
         {
-            ValidateFrameBufferAttachment(desc.ColorTargets[i], $"color target at attachment slot {i}");
+            ValidateFrameBufferAttachment(desc.ColorTargets[i], $"color target at index {i}");
         }
 
         if (desc.DepthStencilTarget is not null)
@@ -461,8 +418,7 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Shader bytecode cannot be null. " +
-                                         "Provide valid compiled shader bytecode.");
+                                         "Shader bytecode cannot be null.");
 
             return;
         }
@@ -471,16 +427,14 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Shader bytecode is empty. " +
-                                         "Provide valid compiled shader bytecode with non-zero length.");
+                                         "Shader bytecode cannot be empty.");
         }
 
         if (string.IsNullOrEmpty(desc.EntryPoint))
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Shader entry point name is missing. " +
-                                         "Specify the function name that serves as the shader's entry point (e.g., 'main', 'VSMain', etc.).");
+                                         "Shader entry point must be specified.");
         }
 
         ValidateDefinedEnum(desc.Stage, "shader stage");
@@ -496,34 +450,31 @@ internal class ResourceValidator(GraphicsContext context)
             {
                 RasterizerState rasterizerState = renderStates.RasterizerState;
 
-                ValidateDefinedEnum(rasterizerState.CullMode, "rasterizer cull mode");
+                ValidateDefinedEnum(rasterizerState.CullMode, "cull mode");
 
-                ValidateDefinedEnum(rasterizerState.FillMode, "rasterizer fill mode");
+                ValidateDefinedEnum(rasterizerState.FillMode, "fill mode");
 
-                ValidateDefinedEnum(rasterizerState.FrontFace, "rasterizer front face winding order");
+                ValidateDefinedEnum(rasterizerState.FrontFace, "front face");
 
                 if (rasterizerState.DepthBias < 0)
                 {
                     context.PublishDebugCallback(MessageCategory.System,
                                                  MessageSeverity.Error,
-                                                 $"Rasterizer depth bias ({rasterizerState.DepthBias}) must be greater than or equal to zero. " +
-                                                 "Negative depth bias values are not supported.");
+                                                 "Depth bias must be non-negative.");
                 }
 
                 if (rasterizerState.DepthBiasClamp < 0)
                 {
                     context.PublishDebugCallback(MessageCategory.System,
                                                  MessageSeverity.Error,
-                                                 $"Rasterizer depth bias clamp ({rasterizerState.DepthBiasClamp}) must be greater than or equal to zero. " +
-                                                 "This value limits the maximum depth bias applied.");
+                                                 "Depth bias clamp must be non-negative.");
                 }
 
                 if (rasterizerState.SlopeScaledDepthBias < 0)
                 {
                     context.PublishDebugCallback(MessageCategory.System,
                                                  MessageSeverity.Error,
-                                                 $"Rasterizer slope scaled depth bias ({rasterizerState.SlopeScaledDepthBias}) must be greater than or equal to zero. " +
-                                                 "This value scales the depth bias based on polygon slope.");
+                                                 "Slope scaled depth bias must be non-negative.");
                 }
             }
 
@@ -531,25 +482,22 @@ internal class ResourceValidator(GraphicsContext context)
             {
                 DepthStencilState depthStencilState = renderStates.DepthStencilState;
 
-                ValidateDefinedEnum(depthStencilState.DepthFunc, "depth comparison function");
+                ValidateDefinedEnum(depthStencilState.DepthFunc, "depth function");
 
-                ValidateDepthStencilStateOp(depthStencilState.FrontFace, "front-facing polygons");
+                ValidateDepthStencilStateOp(depthStencilState.FrontFace, "front face");
 
-                ValidateDepthStencilStateOp(depthStencilState.BackFace, "back-facing polygons");
+                ValidateDepthStencilStateOp(depthStencilState.BackFace, "back face");
             }
 
             // BlendState
             {
                 BlendState blendState = renderStates.BlendState;
 
-                BlendStateRenderTarget[] renderTargets = blendState.IndependentBlendEnable
-                    ? [blendState.RenderTarget0, blendState.RenderTarget1, blendState.RenderTarget2, blendState.RenderTarget3,
-                       blendState.RenderTarget4, blendState.RenderTarget5, blendState.RenderTarget6, blendState.RenderTarget7]
-                    : [blendState.RenderTarget0];
+                BlendStateRenderTarget[] renderTargets = blendState.IndependentBlendEnable ? [blendState.RenderTarget0, blendState.RenderTarget1, blendState.RenderTarget2, blendState.RenderTarget3, blendState.RenderTarget4, blendState.RenderTarget5, blendState.RenderTarget6, blendState.RenderTarget7] : [blendState.RenderTarget0];
 
                 for (int i = 0; i < renderTargets.Length; i++)
                 {
-                    ValidateBlendStateRenderTarget(renderTargets[i], $"blend state render target {i}");
+                    ValidateBlendStateRenderTarget(renderTargets[i], $"render target at index {i}");
                 }
             }
         }
@@ -562,12 +510,12 @@ internal class ResourceValidator(GraphicsContext context)
 
             if (shaders.Hull is not null)
             {
-                ValidateShader(shaders.Hull, "Hull (tessellation control) shader");
+                ValidateShader(shaders.Hull, "Hull shader");
             }
 
             if (shaders.Domain is not null)
             {
-                ValidateShader(shaders.Domain, "Domain (tessellation evaluation) shader");
+                ValidateShader(shaders.Domain, "Domain shader");
             }
 
             if (shaders.Geometry is not null)
@@ -575,15 +523,14 @@ internal class ResourceValidator(GraphicsContext context)
                 ValidateShader(shaders.Geometry, "Geometry shader");
             }
 
-            ValidateShader(shaders.Pixel, "Pixel (fragment) shader");
+            ValidateShader(shaders.Pixel, "Pixel shader");
         }
 
         if (desc.InputLayouts is null || desc.InputLayouts.Length is 0)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Graphics pipeline must have at least one input layout. " +
-                                         "Define the vertex input layout that describes how vertex data is organized.");
+                                         "Graphics pipeline must specify at least 1 input layout.");
         }
 
         ValidateResourceLayouts(desc.ResourceLayouts);
@@ -597,8 +544,7 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Compute pipeline must reference a valid compute shader that is not null and not disposed. " +
-                                         "Ensure the compute shader exists and has not been disposed.");
+                                         "Compute pipeline requires a valid, non-disposed shader.");
         }
 
         ValidateResourceLayouts(desc.ResourceLayouts);
@@ -612,21 +558,20 @@ internal class ResourceValidator(GraphicsContext context)
 
             ValidateShader(shaders.RayGeneration, "Ray generation shader");
 
-            ValidateShaders(shaders.Miss, "Miss shader array");
+            ValidateShaders(shaders.Miss, "Miss shaders");
 
-            ValidateShaders(shaders.AnyHit, "Any-hit shader array");
+            ValidateShaders(shaders.AnyHit, "Any-hit shaders");
 
-            ValidateShaders(shaders.Intersection, "Intersection shader array");
+            ValidateShaders(shaders.Intersection, "Intersection shaders");
 
-            ValidateShaders(shaders.ClosestHit, "Closest-hit shader array");
+            ValidateShaders(shaders.ClosestHit, "Closest-hit shaders");
         }
 
         if (desc.HitGroups is null)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Ray tracing pipeline hit groups array cannot be null. " +
-                                         "Provide a valid array of hit groups that define shader combinations for ray-triangle intersections.");
+                                         "Ray tracing pipeline hit groups cannot be null.");
         }
         else
         {
@@ -640,8 +585,7 @@ internal class ResourceValidator(GraphicsContext context)
                 {
                     context.PublishDebugCallback(MessageCategory.System,
                                                  MessageSeverity.Error,
-                                                 $"Hit group at index {i} has an empty or null name. " +
-                                                 "Each hit group must have a unique, non-empty name for shader table indexing.");
+                                                 $"Hit group at index {i} must have a name.");
                 }
             }
 
@@ -649,14 +593,9 @@ internal class ResourceValidator(GraphicsContext context)
 
             if (hitGroupNames.Distinct().Count() != hitGroupNames.Length)
             {
-                var duplicates = hitGroupNames.GroupBy(static x => x)
-                                              .Where(static g => g.Count() > 1)
-                                              .Select(static g => g.Key);
-
                 context.PublishDebugCallback(MessageCategory.System,
                                              MessageSeverity.Error,
-                                             $"Ray tracing pipeline contains duplicate hit group names: {string.Join(", ", duplicates)}. " +
-                                             "Each hit group must have a unique name for proper shader table addressing.");
+                                             "Hit group names must be unique.");
             }
         }
 
@@ -666,24 +605,21 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Max trace recursion depth ({desc.MaxTraceRecursionDepth}) exceeds the maximum supported value of 31. " +
-                                         "This is a hardware limitation for ray tracing recursion depth.");
+                                         $"Max trace recursion depth must not exceed 31. Got: {desc.MaxTraceRecursionDepth}.");
         }
 
         if (desc.MaxPayloadSizeInBytes % 4 is not 0)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Max payload size ({desc.MaxPayloadSizeInBytes} bytes) must be a multiple of 4. " +
-                                         "Ray tracing payloads must be aligned to 4-byte boundaries.");
+                                         $"Max payload size must be a multiple of 4 bytes. Got: {desc.MaxPayloadSizeInBytes}.");
         }
 
         if (desc.MaxAttributeSizeInBytes % 4 is not 0 or > 32)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Max attribute size ({desc.MaxAttributeSizeInBytes} bytes) must be a multiple of 4 and not exceed 32 bytes. " +
-                                         "This is a hardware limitation for ray-triangle intersection attributes.");
+                                         $"Max attribute size must be a multiple of 4 bytes and not exceed 32 bytes. Got: {desc.MaxAttributeSizeInBytes}.");
         }
     }
 
@@ -695,52 +631,60 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Surface handles array cannot be null. " +
-                                         "Provide the platform-specific window/surface handles required for presentation.");
+                                         "Surface handles cannot be null.");
 
             return;
         }
 
-        string expectedHandles = surface.Type switch
-        {
-            SurfaceType.Win32 => "1 handle (HWND)",
-            SurfaceType.Wayland => "2 handles (display, surface)",
-            SurfaceType.Xlib => "2 handles (display, window)",
-            SurfaceType.Android => "1 handle (ANativeWindow)",
-            SurfaceType.IOS => "1 handle (UIView/CAMetalLayer)",
-            SurfaceType.MacOS => "1 handle (NSView/CAMetalLayer)",
-            _ => "unknown number of handles"
-        };
-
-        int expectedCount = surface.Type switch
-        {
-            SurfaceType.Win32 or SurfaceType.Android or SurfaceType.IOS or SurfaceType.MacOS => 1,
-            SurfaceType.Wayland or SurfaceType.Xlib => 2,
-            _ => -1
-        };
-
-        if (expectedCount != -1 && surface.Handles.Length != expectedCount)
+        if (surface.Type is SurfaceType.Win32 && surface.Handles.Length is not 1)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Surface type '{surface.Type}' requires exactly {expectedHandles}, but {surface.Handles.Length} were provided. " +
-                                         "Ensure you provide the correct number of platform-specific handles.");
+                                         "Win32 surface requires exactly 1 handle (HWND).");
+        }
+        else if (surface.Type is SurfaceType.Wayland && surface.Handles.Length is not 2)
+        {
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "Wayland surface requires exactly 2 handles (display and surface).");
+        }
+        else if (surface.Type is SurfaceType.Xlib && surface.Handles.Length is not 2)
+        {
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "Xlib surface requires exactly 2 handles (display and window).");
+        }
+        else if (surface.Type is SurfaceType.Android && surface.Handles.Length is not 1)
+        {
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "Android surface requires exactly 1 handle (native window).");
+        }
+        else if (surface.Type is SurfaceType.IOS && surface.Handles.Length is not 1)
+        {
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "iOS surface requires exactly 1 handle (view).");
+        }
+        else if (surface.Type is SurfaceType.MacOS && surface.Handles.Length is not 1)
+        {
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "MacOS surface requires exactly 1 handle (view).");
         }
 
         if (surface.Handles.Any(static item => item is 0))
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Surface handles contain null (zero) values. " +
-                                         "All platform handles must be valid, non-zero pointers.");
+                                         "Surface handles cannot contain null pointers.");
         }
 
         if (surface.Width is 0 || surface.Height is 0)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Surface dimensions are invalid. Width ({surface.Width}) and height ({surface.Height}) must both be greater than zero. " +
-                                         "Specify valid window/surface dimensions.");
+                                         "Surface dimensions must be greater than 0.");
         }
     }
 
@@ -750,20 +694,18 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Frame buffer {name} references an invalid texture. " +
-                                         "The texture must be valid, non-null, and not disposed.");
+                                         $"Frame buffer {name} requires a valid, non-disposed texture.");
 
             return;
         }
 
         ObtainTextureValues(attachment.Target, out TextureType type, out uint layers, out uint mipLevels, name);
 
-        if (type is not TextureType.Texture2D and not TextureType.Texture2DArray)
+        if (type is not TextureType.Texture2D or TextureType.Texture2DArray)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Frame buffer {name} has invalid texture type '{type}'. " +
-                                         "Only Texture2D and Texture2DArray are supported as frame buffer attachments.");
+                                         $"Frame buffer {name} must use Texture2D or Texture2DArray. Got: {type}.");
         }
 
         ValidateTextureSlice(type, layers, mipLevels, attachment.Slice, name);
@@ -771,26 +713,26 @@ internal class ResourceValidator(GraphicsContext context)
 
     private void ValidateDepthStencilStateOp(DepthStencilStateOp stateOp, string name)
     {
-        ValidateDefinedEnum(stateOp.StencilFailOp, $"stencil fail operation for {name}");
+        ValidateDefinedEnum(stateOp.StencilFailOp, $"{name} stencil fail operation");
 
-        ValidateDefinedEnum(stateOp.StencilDepthFailOp, $"stencil depth fail operation for {name}");
+        ValidateDefinedEnum(stateOp.StencilDepthFailOp, $"{name} stencil depth fail operation");
 
-        ValidateDefinedEnum(stateOp.StencilPassOp, $"stencil pass operation for {name}");
+        ValidateDefinedEnum(stateOp.StencilPassOp, $"{name} stencil pass operation");
 
-        ValidateDefinedEnum(stateOp.StencilFunc, $"stencil comparison function for {name}");
+        ValidateDefinedEnum(stateOp.StencilFunc, $"{name} stencil function");
     }
 
     private void ValidateBlendStateRenderTarget(BlendStateRenderTarget renderTarget, string name)
     {
-        ValidateDefinedEnum(renderTarget.SrcBlend, $"{name} source color blend factor");
+        ValidateDefinedEnum(renderTarget.SrcBlend, $"{name} source blend");
 
-        ValidateDefinedEnum(renderTarget.DestBlend, $"{name} destination color blend factor");
+        ValidateDefinedEnum(renderTarget.DestBlend, $"{name} destination blend");
 
-        ValidateDefinedEnum(renderTarget.BlendOp, $"{name} color blend operation");
+        ValidateDefinedEnum(renderTarget.BlendOp, $"{name} blend operation");
 
-        ValidateDefinedEnum(renderTarget.SrcBlendAlpha, $"{name} source alpha blend factor");
+        ValidateDefinedEnum(renderTarget.SrcBlendAlpha, $"{name} source alpha blend");
 
-        ValidateDefinedEnum(renderTarget.DestBlendAlpha, $"{name} destination alpha blend factor");
+        ValidateDefinedEnum(renderTarget.DestBlendAlpha, $"{name} destination alpha blend");
 
         ValidateDefinedEnum(renderTarget.BlendOpAlpha, $"{name} alpha blend operation");
     }
@@ -801,8 +743,7 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"{name} cannot be null. " +
-                                         "Provide a valid array of shaders, even if empty.");
+                                         $"{name} cannot be null.");
 
             return;
         }
@@ -819,8 +760,7 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Pipeline resource layouts array cannot be null. " +
-                                         "Provide a valid array of resource layouts that define the pipeline's resource bindings.");
+                                         "Resource layouts cannot be null.");
 
             return;
         }
@@ -833,8 +773,7 @@ internal class ResourceValidator(GraphicsContext context)
             {
                 context.PublishDebugCallback(MessageCategory.System,
                                              MessageSeverity.Error,
-                                             $"Resource layout at set index {i} is null or disposed. " +
-                                             $"All resource layouts must be valid, non-null, and not disposed.");
+                                             $"Resource layout at index {i} must be valid and non-disposed.");
             }
         }
     }
@@ -845,8 +784,7 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Pipeline output color attachments array cannot be null. " +
-                                         "Provide a valid array of color attachment formats, even if empty.");
+                                         "Output color attachments cannot be null.");
 
             return;
         }
@@ -855,8 +793,7 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Pipeline output must have at least one render target. " +
-                                         "Specify either one or more color attachment formats, or a depth-stencil format, or both.");
+                                         "Output must have at least 1 color attachment or a depth-stencil attachment.");
 
             return;
         }
@@ -865,16 +802,14 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Pipeline output has too many color attachments ({output.ColorAttachments.Length}). " +
-                                         "Maximum supported color attachments is 8. This is a hardware limitation on most GPUs.");
+                                         $"Output supports up to 8 color attachments. Got: {output.ColorAttachments.Length}.");
         }
 
         if (output.DepthStencilAttachment is not null && !depthStencilFormats.Contains(output.DepthStencilAttachment.Value))
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Pipeline output depth-stencil format '{output.DepthStencilAttachment.Value}' is not supported. " +
-                                         $"Supported depth-stencil formats are: {string.Join(", ", depthStencilFormats.Select(static item => item.ToString()))}.");
+                                         $"Depth-stencil attachment format '{output.DepthStencilAttachment.Value}' is not supported. Valid formats: {string.Join(", ", depthStencilFormats.Select(static item => item.ToString()))}.");
         }
     }
 
@@ -885,8 +820,7 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Invalid {name} value '{value}'. " +
-                                         $"Valid values are: {string.Join(", ", Enum.GetNames<TEnum>())}.");
+                                         $"Invalid {name} value '{value}'. Valid values: {string.Join(", ", Enum.GetNames<TEnum>())}.");
         }
     }
 
@@ -896,8 +830,7 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"{name} is required but is null or disposed. " +
-                                         "Ensure the shader is created and not disposed before using it in a pipeline.");
+                                         $"{name} must be valid and non-disposed.");
         }
     }
     #endregion
@@ -929,8 +862,7 @@ internal class ResourceValidator(GraphicsContext context)
 
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Unexpected texture type in {name}. " +
-                                         $"Expected Texture or TextureView, but got '{iTexture.GetType().Name}'.");
+                                         $"Cannot validate texture slice for {name}: expected Texture or TextureView.");
         }
     }
 
@@ -946,16 +878,14 @@ internal class ResourceValidator(GraphicsContext context)
             {
                 context.PublishDebugCallback(MessageCategory.System,
                                              MessageSeverity.Error,
-                                             $"Invalid cube face index {slice.Face} for {name}. " +
-                                             $"Cube textures have 6 faces (0-5). Valid range is 0 to 5.");
+                                             $"Face index {slice.Face} is invalid for {name}. Cube textures have 6 faces (0-5).");
             }
         }
         else if (slice.Face is not 0)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Invalid face index {slice.Face} for {name} with texture type '{type}'. " +
-                                         "Only TextureCube and TextureCubeArray support multiple faces. Use Face = 0 for other texture types.");
+                                         $"Face index must be 0 for non-cube texture {name}.");
         }
 
         if (arrayTextureTypes.Contains(type))
@@ -964,24 +894,21 @@ internal class ResourceValidator(GraphicsContext context)
             {
                 context.PublishDebugCallback(MessageCategory.System,
                                              MessageSeverity.Error,
-                                             $"Invalid layer index {slice.Layer} for {name}. " +
-                                             $"The texture has {layers} layers. Valid range is 0 to {layers - 1}.");
+                                             $"Layer index {slice.Layer} exceeds layer count ({layers}) for {name}.");
             }
         }
         else if (slice.Layer is not 0)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Invalid layer index {slice.Layer} for {name} with texture type '{type}'. " +
-                                         "Only array texture types support multiple layers. Use Layer = 0 for non-array textures.");
+                                         $"Layer index must be 0 for non-array texture {name}.");
         }
 
         if (slice.MipLevel >= mipLevels)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Invalid mip level {slice.MipLevel} for {name}. " +
-                                         $"The texture has {mipLevels} mip levels. Valid range is 0 to {mipLevels - 1}.");
+                                         $"Mip level {slice.MipLevel} exceeds mip level count ({mipLevels}) for {name}.");
         }
     }
     #endregion

--- a/sources/Zenith.NET/ResourceValidator.cs
+++ b/sources/Zenith.NET/ResourceValidator.cs
@@ -68,9 +68,9 @@ internal class ResourceValidator(GraphicsContext context)
             context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Buffer view size exceeds the buffer's size. Ensure that OffsetInBytes + SizeInBytes does not exceed the buffer's SizeInBytes ({desc.Buffer.Desc.SizeInBytes}).");
         }
 
-        if (desc.SizeInBytes % desc.Buffer.Desc.StrideInBytes is not 0)
+        if (desc.StrideInBytes is 0)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Warning, "Buffer view size is not a multiple of the buffer's stride. This may lead to unexpected behavior, especially when using structured buffers.");
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Warning, "Buffer view stride is zero. This may lead to unexpected behavior, especially when using structured buffers. Consider setting a non-zero stride.");
         }
     }
 

--- a/sources/Zenith.NET/ResourceValidator.cs
+++ b/sources/Zenith.NET/ResourceValidator.cs
@@ -145,6 +145,59 @@ internal class ResourceValidator(GraphicsContext context)
         }
     }
 
+    public void ValidateSamplerDesc(SamplerDesc desc)
+    {
+        if (!Enum.IsDefined(desc.U))
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid U address mode: {desc.U}. Supported modes are: {string.Join(", ", Enum.GetNames<AddressMode>())}.");
+        }
+
+        if (!Enum.IsDefined(desc.V))
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid V address mode: {desc.V}. Supported modes are: {string.Join(", ", Enum.GetNames<AddressMode>())}.");
+        }
+
+        if (!Enum.IsDefined(desc.W))
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid W address mode: {desc.W}. Supported modes are: {string.Join(", ", Enum.GetNames<AddressMode>())}.");
+        }
+
+        if (!Enum.IsDefined(desc.Filter))
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid filter: {desc.Filter}. Supported filters are: {string.Join(", ", Enum.GetNames<Filter>())}.");
+        }
+
+        if (!Enum.IsDefined(desc.ComparisonFunc))
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid comparison function: {desc.ComparisonFunc}. Supported functions are: {string.Join(", ", Enum.GetNames<ComparisonFunc>())}.");
+        }
+
+        if (desc.MaxAnisotropy is not 1 and not 2 and not 4 and not 8 and not 16)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid max anisotropy: {desc.MaxAnisotropy}. Supported values are: 1, 2, 4, 8, or 16.");
+        }
+
+        if (desc.MinLod < 0)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "MinLod must be greater than or equal to zero.");
+        }
+
+        if (desc.MaxLod < desc.MinLod)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "MaxLod must be greater than or equal to MinLod.");
+        }
+
+        if (desc.LodBias < -16 || desc.LodBias > 16)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "LodBias must be between -16 and 16.");
+        }
+
+        if (!Enum.IsDefined(desc.BorderColor))
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid border color: {desc.BorderColor}. Supported colors are: {string.Join(", ", Enum.GetNames<BorderColor>())}.");
+        }
+    }
+
     private void ValidateSurface(Surface surface)
     {
         if (!Enum.IsDefined(surface.Type))

--- a/sources/Zenith.NET/ResourceValidator.cs
+++ b/sources/Zenith.NET/ResourceValidator.cs
@@ -449,7 +449,15 @@ internal class ResourceValidator(GraphicsContext context)
 
     public void ValidateComputePipelineDesc(ComputePipelineDesc desc)
     {
-        throw new NotImplementedException();
+        if (desc.Shader?.IsDisposed is not false)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Compute pipeline must reference a valid shader that is not disposed.");
+        }
+
+        if (desc.ResourceLayouts is null)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Compute pipeline resource layouts cannot be null.");
+        }
     }
 
     public void ValidateRayTracingPipelineDesc(RayTracingPipelineDesc desc)

--- a/sources/Zenith.NET/ResourceValidator.cs
+++ b/sources/Zenith.NET/ResourceValidator.cs
@@ -23,12 +23,12 @@ internal class ResourceValidator(GraphicsContext context)
 
         if (!swapChainFormats.Contains(desc.ColorTargetFormat))
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid color target format: {desc.ColorTargetFormat}. Supported formats are: {string.Join(", ", swapChainFormats.Select(f => f.ToString()))}.");
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid color target format: {desc.ColorTargetFormat}. Supported formats are: {string.Join(", ", swapChainFormats.Select(static item => item.ToString()))}.");
         }
 
         if (desc.DepthStencilTargetFormat.HasValue && !depthStencilFormats.Contains(desc.DepthStencilTargetFormat.Value))
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid depth-stencil target format: {desc.DepthStencilTargetFormat.Value}. Supported formats are: {string.Join(", ", depthStencilFormats.Select(f => f.ToString()))}.");
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid depth-stencil target format: {desc.DepthStencilTargetFormat.Value}. Supported formats are: {string.Join(", ", depthStencilFormats.Select(static item => item.ToString()))}.");
         }
     }
 
@@ -345,7 +345,99 @@ internal class ResourceValidator(GraphicsContext context)
 
     public void ValidateGraphicsPipelineDesc(GraphicsPipelineDesc desc)
     {
-        ValidateRenderStates(desc.RenderStates);
+        // RenderStates
+        {
+            RenderStates renderStates = desc.RenderStates;
+
+            // RasterizerState
+            {
+                RasterizerState rasterizerState = renderStates.RasterizerState;
+
+                ValidateDefinedEnum(rasterizerState.CullMode, "cull mode");
+
+                ValidateDefinedEnum(rasterizerState.FillMode, "fill mode");
+
+                ValidateDefinedEnum(rasterizerState.FrontFace, "front face");
+
+                if (rasterizerState.DepthBias < 0)
+                {
+                    context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Depth bias must be greater than or equal to zero.");
+                }
+
+                if (rasterizerState.DepthBiasClamp < 0)
+                {
+                    context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Depth bias clamp must be greater than or equal to zero.");
+                }
+
+                if (rasterizerState.SlopeScaledDepthBias < 0)
+                {
+                    context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Slope scaled depth bias must be greater than or equal to zero.");
+                }
+            }
+
+            // DepthStencilState
+            {
+                DepthStencilState depthStencilState = renderStates.DepthStencilState;
+
+                ValidateDefinedEnum(depthStencilState.DepthFunc, "depth function");
+
+                ValidateDepthStencilStateOp(depthStencilState.FrontFace);
+
+                ValidateDepthStencilStateOp(depthStencilState.BackFace);
+            }
+
+            // BlendState
+            {
+                BlendState blendState = renderStates.BlendState;
+
+                foreach (BlendStateRenderTarget renderTarget in (BlendStateRenderTarget[])(blendState.IndependentBlendEnable ? [blendState.RenderTarget0, blendState.RenderTarget1, blendState.RenderTarget2, blendState.RenderTarget3, blendState.RenderTarget4, blendState.RenderTarget5, blendState.RenderTarget6, blendState.RenderTarget7] : [blendState.RenderTarget0]))
+                {
+                    ValidateBlendStateRenderTarget(renderTarget);
+                }
+            }
+        }
+
+        // Shaders
+        {
+            GraphicsShaders shaders = desc.Shaders;
+
+            if (shaders.Vertex?.IsDisposed is not false)
+            {
+                context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Vertex shader must reference a valid shader that is not disposed.");
+            }
+
+            if (shaders.Hull?.IsDisposed is true)
+            {
+                context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Hull shader must reference a valid shader that is not disposed.");
+            }
+
+            if (shaders.Domain?.IsDisposed is true)
+            {
+                context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Domain shader must reference a valid shader that is not disposed.");
+            }
+
+            if (shaders.Geometry?.IsDisposed is true)
+            {
+                context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Geometry shader must reference a valid shader that is not disposed.");
+            }
+
+            if (shaders.Pixel?.IsDisposed is not false)
+            {
+                context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Pixel shader must reference a valid shader that is not disposed.");
+            }
+        }
+
+        if (desc.InputLayouts is null || desc.InputLayouts.Length is 0)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Graphics pipeline must have at least one input layout.");
+        }
+
+        if (desc.ResourceLayouts is null)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Graphics pipeline resource layouts cannot be null.");
+        }
+
+        ValidateOutput(desc.Outputs);
     }
 
     public void ValidateComputePipelineDesc(ComputePipelineDesc desc)
@@ -424,43 +516,58 @@ internal class ResourceValidator(GraphicsContext context)
         ValidateTextureSlice(type, layers, mipLevels, attachment.Slice);
     }
 
-    #region Graphics Pipeline Validation
-    private void ValidateRenderStates(RenderStates renderStates)
+    private void ValidateDepthStencilStateOp(DepthStencilStateOp stateOp)
     {
-        // RasterizerState
+        ValidateDefinedEnum(stateOp.StencilFailOp, "stencil fail operation");
+
+        ValidateDefinedEnum(stateOp.StencilDepthFailOp, "stencil depth fail operation");
+
+        ValidateDefinedEnum(stateOp.StencilPassOp, "stencil pass operation");
+
+        ValidateDefinedEnum(stateOp.StencilFunc, "stencil function");
+    }
+
+    private void ValidateBlendStateRenderTarget(BlendStateRenderTarget renderTarget)
+    {
+        ValidateDefinedEnum(renderTarget.SrcBlend, "source blend");
+
+        ValidateDefinedEnum(renderTarget.DestBlend, "destination blend");
+
+        ValidateDefinedEnum(renderTarget.BlendOp, "blend operation");
+
+        ValidateDefinedEnum(renderTarget.SrcBlendAlpha, "source blend alpha");
+
+        ValidateDefinedEnum(renderTarget.DestBlendAlpha, "destination blend alpha");
+
+        ValidateDefinedEnum(renderTarget.BlendOpAlpha, "blend operation alpha");
+    }
+
+    private void ValidateOutput(Output output)
+    {
+        if (output.ColorAttachments is null)
         {
-            RasterizerState rasterizerState = renderStates.RasterizerState;
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Output color attachments cannot be null.");
 
-            ValidateDefinedEnum(rasterizerState.CullMode, "cull mode");
-
-            ValidateDefinedEnum(rasterizerState.FillMode, "fill mode");
-
-            ValidateDefinedEnum(rasterizerState.FrontFace, "front face");
-
-            if (rasterizerState.DepthBias < 0)
-            {
-                context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Depth bias must be greater than or equal to zero.");
-            }
-
-            if (rasterizerState.DepthBiasClamp < 0)
-            {
-                context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Depth bias clamp must be greater than or equal to zero.");
-            }
-
-            if (rasterizerState.SlopeScaledDepthBias < 0)
-            {
-                context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Slope scaled depth bias must be greater than or equal to zero.");
-            }
+            return;
         }
 
-        // DepthStencilState
+        if (output.ColorAttachments.Length is 0 && output.DepthStencilAttachment is null)
         {
-            DepthStencilState depthStencilState = renderStates.DepthStencilState;
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Output must have at least one color attachment or a depth-stencil attachment.");
 
-            ValidateDefinedEnum(depthStencilState.DepthFunc, "depth function");
+            return;
+        }
+
+        if (output.ColorAttachments.Length > 8)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Output cannot have more than 8 color attachments.");
+        }
+
+        if (output.DepthStencilAttachment is not null && !depthStencilFormats.Contains(output.DepthStencilAttachment.Value))
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid depth-stencil attachment format: {output.DepthStencilAttachment.Value}. Supported formats are: {string.Join(", ", depthStencilFormats.Select(static item => item.ToString()))}.");
         }
     }
-    #endregion
 
     #region Universal Validation
     private void ValidateDefinedEnum<TEnum>(TEnum value, string name) where TEnum : struct, Enum

--- a/sources/Zenith.NET/ResourceValidator.cs
+++ b/sources/Zenith.NET/ResourceValidator.cs
@@ -123,11 +123,6 @@ internal class ResourceValidator(GraphicsContext context)
             return;
         }
 
-        if (desc.MipLevel >= desc.Texture.Desc.MipLevels)
-        {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid mip level: {desc.MipLevel}. It must be less than the texture's mip levels ({desc.Texture.Desc.MipLevels}).");
-        }
-
         if (desc.FirstLayer >= desc.Texture.Desc.Layers)
         {
             context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid first layer: {desc.FirstLayer}. It must be less than the texture's layers ({desc.Texture.Desc.Layers}).");
@@ -140,6 +135,20 @@ internal class ResourceValidator(GraphicsContext context)
         else if (desc.FirstLayer + desc.LayerCount > desc.Texture.Desc.Layers)
         {
             context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Texture view layer count exceeds the texture's layers. Ensure that FirstLayer + LayerCount does not exceed the texture's Layers ({desc.Texture.Desc.Layers}).");
+        }
+
+        if (desc.FirstMipLevel >= desc.Texture.Desc.MipLevels)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid first mip level: {desc.FirstMipLevel}. It must be less than the texture's mip levels ({desc.Texture.Desc.MipLevels}).");
+        }
+
+        if (desc.MipLevelCount is 0)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Texture view mip level count must be greater than zero.");
+        }
+        else if (desc.FirstMipLevel + desc.MipLevelCount > desc.Texture.Desc.MipLevels)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Texture view mip level count exceeds the texture's mip levels. Ensure that FirstMipLevel + MipLevelCount does not exceed the texture's MipLevels ({desc.Texture.Desc.MipLevels}).");
         }
     }
 
@@ -394,6 +403,7 @@ internal class ResourceValidator(GraphicsContext context)
 
     private void ValidateTextureSlice(ITexture texture, TextureSlice slice)
     {
-        throw new NotImplementedException("Texture slice validation is not implemented yet. This method should check if the slice parameters are valid for the given texture type and dimensions.");
+        TextureType type;
+
     }
 }

--- a/sources/Zenith.NET/ResourceValidator.cs
+++ b/sources/Zenith.NET/ResourceValidator.cs
@@ -346,6 +346,31 @@ internal class ResourceValidator(GraphicsContext context)
         }
     }
 
+    public void ValidateShaderDesc(ShaderDesc desc)
+    {
+        if (desc.ShaderBytes is null)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Shader bytecode cannot be null.");
+
+            return;
+        }
+
+        if (desc.ShaderBytes.Length is 0)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Shader bytecode must not be empty.");
+        }
+
+        if (string.IsNullOrEmpty(desc.EntryPoint))
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Shader entry point must not be null or empty.");
+        }
+
+        if (!Enum.IsDefined(desc.Stage))
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid shader stage: {desc.Stage}. Supported stages are: {string.Join(", ", Enum.GetNames<ShaderStageFlags>())}.");
+        }
+    }
+
     private void ValidateSurface(Surface surface)
     {
         if (!Enum.IsDefined(surface.Type))

--- a/sources/Zenith.NET/ResourceValidator.cs
+++ b/sources/Zenith.NET/ResourceValidator.cs
@@ -43,11 +43,6 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Warning, "Buffer stride is zero. This may lead to unexpected behavior, especially when using structured buffers. Consider setting a non-zero stride.");
         }
-
-        if (desc.Flags is BufferUsageFlags.None)
-        {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Buffer usage flags cannot be None. At least one flag must be set.");
-        }
     }
 
     public void ValidateBufferViewDesc(BufferViewDesc desc)
@@ -55,23 +50,98 @@ internal class ResourceValidator(GraphicsContext context)
         if (desc.Buffer?.IsDisposed is not false)
         {
             context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Buffer view must reference a valid buffer that is not disposed.");
+
+            return;
         }
-        else
+
+        if (desc.OffsetInBytes >= desc.Buffer.Desc.SizeInBytes)
         {
-            if (desc.OffsetInBytes + desc.SizeInBytes > desc.Buffer.Desc.SizeInBytes)
-            {
-                context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Buffer view size exceeds the buffer size. Ensure that OffsetInBytes + SizeInBytes does not exceed the buffer's SizeInBytes.");
-            }
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid offset: {desc.OffsetInBytes}. It must be less than the buffer's size ({desc.Buffer.Desc.SizeInBytes}).");
+        }
 
-            if (desc.SizeInBytes is 0)
-            {
-                context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Buffer view size must be greater than zero.");
-            }
+        if (desc.SizeInBytes is 0)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Buffer view size must be greater than zero.");
+        }
+        else if (desc.OffsetInBytes + desc.SizeInBytes > desc.Buffer.Desc.SizeInBytes)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Buffer view size exceeds the buffer's size. Ensure that OffsetInBytes + SizeInBytes does not exceed the buffer's SizeInBytes ({desc.Buffer.Desc.SizeInBytes}).");
+        }
 
-            if (desc.SizeInBytes % desc.Buffer.Desc.StrideInBytes is not 0)
-            {
-                context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Warning, "Buffer view size is not a multiple of the buffer's stride. This may lead to unexpected behavior, especially when using structured buffers.");
-            }
+        if (desc.SizeInBytes % desc.Buffer.Desc.StrideInBytes is not 0)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Warning, "Buffer view size is not a multiple of the buffer's stride. This may lead to unexpected behavior, especially when using structured buffers.");
+        }
+    }
+
+    public void ValidateTextureDesc(TextureDesc desc)
+    {
+        if (!Enum.IsDefined(desc.Type))
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid texture type: {desc.Type}. Supported types are: {string.Join(", ", Enum.GetNames<TextureType>())}.");
+
+            return;
+        }
+
+        if (desc.Type is TextureType.Texture1D or TextureType.Texture1DArray && desc.Width is 0)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Texture width must be greater than zero for 1D textures.");
+        }
+        else if (desc.Type is TextureType.Texture2D or TextureType.Texture2DArray && (desc.Width is 0 || desc.Height is 0))
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Texture width and height must be greater than zero for 2D textures.");
+        }
+        else if (desc.Type is TextureType.Texture3D && (desc.Width is 0 || desc.Height is 0 || desc.Depth is 0))
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Texture width, height, and depth must be greater than zero for 3D textures.");
+        }
+        else if (desc.Type is TextureType.TextureCube or TextureType.TextureCubeArray && (desc.Width is 0 || desc.Height is 0 || desc.Width != desc.Height))
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Texture width and height must be equal and greater than zero for cube textures.");
+        }
+
+        if (desc.Layers is 0)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Texture layers must be greater than zero.");
+        }
+
+        if (desc.MipLevels is 0)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Texture mip levels must be greater than zero.");
+        }
+
+        if (!Enum.IsDefined(desc.SampleCount))
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid sample count: {desc.SampleCount}. Supported sample counts are: {string.Join(", ", Enum.GetNames<SampleCount>())}.");
+        }
+    }
+
+    public void ValidateTextureViewDesc(TextureViewDesc desc)
+    {
+        if (desc.Texture?.IsDisposed is not false)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Texture view must reference a valid texture that is not disposed.");
+
+            return;
+        }
+
+        if (desc.MipLevel >= desc.Texture.Desc.MipLevels)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid mip level: {desc.MipLevel}. It must be less than the texture's mip levels ({desc.Texture.Desc.MipLevels}).");
+        }
+
+        if (desc.FirstLayer >= desc.Texture.Desc.Layers)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid first layer: {desc.FirstLayer}. It must be less than the texture's layers ({desc.Texture.Desc.Layers}).");
+        }
+
+        if (desc.LayerCount is 0)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Texture view layer count must be greater than zero.");
+        }
+        else if (desc.FirstLayer + desc.LayerCount > desc.Texture.Desc.Layers)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Texture view layer count exceeds the texture's layers. Ensure that FirstLayer + LayerCount does not exceed the texture's Layers ({desc.Texture.Desc.Layers}).");
         }
     }
 

--- a/sources/Zenith.NET/ResourceValidator.cs
+++ b/sources/Zenith.NET/ResourceValidator.cs
@@ -32,14 +32,16 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Invalid color target format: {desc.ColorTargetFormat}. Supported formats are: {string.Join(", ", swapChainFormats.Select(static item => item.ToString()))}.");
+                                         $"Invalid swap chain color target format '{desc.ColorTargetFormat}'. " +
+                                         $"Supported formats are: {string.Join(", ", swapChainFormats.Select(static item => item.ToString()))}.");
         }
 
         if (desc.DepthStencilTargetFormat.HasValue && !depthStencilFormats.Contains(desc.DepthStencilTargetFormat.Value))
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Invalid depth-stencil target format: {desc.DepthStencilTargetFormat.Value}. Supported formats are: {string.Join(", ", depthStencilFormats.Select(static item => item.ToString()))}.");
+                                         $"Invalid swap chain depth-stencil target format '{desc.DepthStencilTargetFormat.Value}'. " +
+                                         $"Supported formats are: {string.Join(", ", depthStencilFormats.Select(static item => item.ToString()))}.");
         }
     }
 
@@ -49,14 +51,15 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Buffer size must be greater than zero.");
+                                         "Buffer size must be greater than zero. A buffer with zero size cannot be created.");
         }
 
         if (desc.StrideInBytes is 0)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Warning,
-                                         "Buffer stride is zero. This may lead to unexpected behavior, especially when using structured buffers. Consider setting a non-zero stride.");
+                                         "Buffer stride is zero. This may lead to unexpected behavior when using structured buffers. " +
+                                         "Consider setting a non-zero stride that matches your data structure size.");
         }
     }
 
@@ -66,7 +69,8 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Buffer view must reference a valid buffer that is not disposed.");
+                                         "Buffer view must reference a valid buffer that is not null and not disposed. " +
+                                         "Ensure the buffer exists and has not been disposed before creating the view.");
 
             return;
         }
@@ -75,27 +79,31 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Invalid offset: {desc.OffsetInBytes}. It must be less than the buffer's size ({desc.Buffer.Desc.SizeInBytes}).");
+                                         $"Buffer view offset ({desc.OffsetInBytes} bytes) must be less than the buffer's total size ({desc.Buffer.Desc.SizeInBytes} bytes). " +
+                                         $"Valid range is 0 to {desc.Buffer.Desc.SizeInBytes - 1}.");
         }
 
         if (desc.SizeInBytes is 0)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Buffer view size must be greater than zero.");
+                                         "Buffer view size must be greater than zero. A view with zero size cannot be created.");
         }
         else if (desc.OffsetInBytes + desc.SizeInBytes > desc.Buffer.Desc.SizeInBytes)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Buffer view size exceeds the buffer's size. Ensure that OffsetInBytes + SizeInBytes does not exceed the buffer's SizeInBytes ({desc.Buffer.Desc.SizeInBytes}).");
+                                         $"Buffer view range exceeds buffer bounds. View range [{desc.OffsetInBytes}, {desc.OffsetInBytes + desc.SizeInBytes}) " +
+                                         $"exceeds buffer size ({desc.Buffer.Desc.SizeInBytes} bytes). " +
+                                         $"Ensure that OffsetInBytes + SizeInBytes ≤ {desc.Buffer.Desc.SizeInBytes}.");
         }
 
         if (desc.StrideInBytes is 0)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Warning,
-                                         "Buffer view stride is zero. This may lead to unexpected behavior, especially when using structured buffers. Consider setting a non-zero stride.");
+                                         "Buffer view stride is zero. This may lead to unexpected behavior when using structured buffers. " +
+                                         "Consider setting a non-zero stride that matches your data structure size.");
         }
     }
 
@@ -109,25 +117,29 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Texture width must be greater than zero for 1D textures.");
+                                         "Texture width must be greater than zero for 1D textures. " +
+                                         "Specify a valid width for the texture dimensions.");
         }
         else if (desc.Type is TextureType.Texture2D or TextureType.Texture2DArray && (desc.Width is 0 || desc.Height is 0))
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Texture width and height must be greater than zero for 2D textures.");
+                                         $"Texture width ({desc.Width}) and height ({desc.Height}) must both be greater than zero for 2D textures. " +
+                                         "Specify valid dimensions for both width and height.");
         }
         else if (desc.Type is TextureType.Texture3D && (desc.Width is 0 || desc.Height is 0 || desc.Depth is 0))
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Texture width, height, and depth must be greater than zero for 3D textures.");
+                                         $"Texture width ({desc.Width}), height ({desc.Height}), and depth ({desc.Depth}) must all be greater than zero for 3D textures. " +
+                                         "Specify valid dimensions for all three axes.");
         }
         else if (desc.Type is TextureType.TextureCube or TextureType.TextureCubeArray && (desc.Width is 0 || desc.Height is 0 || desc.Width != desc.Height))
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Texture width and height must be equal and greater than zero for cube textures.");
+                                         $"Cube texture dimensions are invalid. Width ({desc.Width}) and height ({desc.Height}) must be equal and greater than zero. " +
+                                         "Cube textures require square faces.");
         }
 
         if (arrayTextureTypes.Contains(desc.Type))
@@ -136,24 +148,27 @@ internal class ResourceValidator(GraphicsContext context)
             {
                 context.PublishDebugCallback(MessageCategory.System,
                                              MessageSeverity.Error,
-                                             "Texture layers must be greater than zero.");
+                                             $"Texture array layers must be greater than zero for {desc.Type}. " +
+                                             "Specify at least one layer for the texture array.");
             }
         }
         else if (desc.Layers is not 1)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Texture layers must be 1 for non-array textures.");
+                                         $"Non-array texture type '{desc.Type}' must have exactly 1 layer, but {desc.Layers} layers were specified. " +
+                                         "Set Layers to 1 for non-array textures.");
         }
 
         if (desc.MipLevels is 0)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Texture mip levels must be greater than zero.");
+                                         "Texture mip levels must be greater than zero. " +
+                                         "Specify at least 1 mip level (the base level) for the texture.");
         }
 
-        ValidateDefinedEnum(desc.SampleCount, "sample count");
+        ValidateDefinedEnum(desc.SampleCount, "texture sample count");
     }
 
     public void ValidateTextureViewDesc(TextureViewDesc desc)
@@ -162,7 +177,8 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Texture view must reference a valid texture that is not disposed.");
+                                         "Texture view must reference a valid texture that is not null and not disposed. " +
+                                         "Ensure the texture exists and has not been disposed before creating the view.");
 
             return;
         }
@@ -171,84 +187,96 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Invalid first layer: {desc.FirstLayer}. It must be less than the texture's layers ({desc.Texture.Desc.Layers}).");
+                                         $"Texture view first layer index ({desc.FirstLayer}) must be less than the texture's total layer count ({desc.Texture.Desc.Layers}). " +
+                                         $"Valid range is 0 to {desc.Texture.Desc.Layers - 1}.");
         }
 
         if (desc.LayerCount is 0)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Texture view layer count must be greater than zero.");
+                                         "Texture view layer count must be greater than zero. " +
+                                         "Specify at least one layer to include in the view.");
         }
         else if (desc.FirstLayer + desc.LayerCount > desc.Texture.Desc.Layers)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Texture view layer count exceeds the texture's layers. Ensure that FirstLayer + LayerCount does not exceed the texture's Layers ({desc.Texture.Desc.Layers}).");
+                                         $"Texture view layer range exceeds texture bounds. View range [{desc.FirstLayer}, {desc.FirstLayer + desc.LayerCount}) " +
+                                         $"exceeds texture layer count ({desc.Texture.Desc.Layers}). " +
+                                         $"Ensure that FirstLayer + LayerCount ≤ {desc.Texture.Desc.Layers}.");
         }
 
         if (desc.FirstMipLevel >= desc.Texture.Desc.MipLevels)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Invalid first mip level: {desc.FirstMipLevel}. It must be less than the texture's mip levels ({desc.Texture.Desc.MipLevels}).");
+                                         $"Texture view first mip level ({desc.FirstMipLevel}) must be less than the texture's total mip levels ({desc.Texture.Desc.MipLevels}). " +
+                                         $"Valid range is 0 to {desc.Texture.Desc.MipLevels - 1}.");
         }
 
         if (desc.MipLevelCount is 0)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Texture view mip level count must be greater than zero.");
+                                         "Texture view mip level count must be greater than zero. " +
+                                         "Specify at least one mip level to include in the view.");
         }
         else if (desc.FirstMipLevel + desc.MipLevelCount > desc.Texture.Desc.MipLevels)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Texture view mip level count exceeds the texture's mip levels. Ensure that FirstMipLevel + MipLevelCount does not exceed the texture's MipLevels ({desc.Texture.Desc.MipLevels}).");
+                                         $"Texture view mip level range exceeds texture bounds. View range [{desc.FirstMipLevel}, {desc.FirstMipLevel + desc.MipLevelCount}) " +
+                                         $"exceeds texture mip levels ({desc.Texture.Desc.MipLevels}). " +
+                                         $"Ensure that FirstMipLevel + MipLevelCount ≤ {desc.Texture.Desc.MipLevels}.");
         }
     }
 
     public void ValidateSamplerDesc(SamplerDesc desc)
     {
-        ValidateDefinedEnum(desc.U, "U address mode");
+        ValidateDefinedEnum(desc.U, "texture U (horizontal) address mode");
 
-        ValidateDefinedEnum(desc.V, "V address mode");
+        ValidateDefinedEnum(desc.V, "texture V (vertical) address mode");
 
-        ValidateDefinedEnum(desc.W, "W address mode");
+        ValidateDefinedEnum(desc.W, "texture W (depth) address mode");
 
-        ValidateDefinedEnum(desc.Filter, "filter");
+        ValidateDefinedEnum(desc.Filter, "texture filter mode");
 
-        ValidateDefinedEnum(desc.ComparisonFunc, "comparison function");
+        ValidateDefinedEnum(desc.ComparisonFunc, "texture comparison function");
 
         if (desc.MaxAnisotropy is not 1 and not 2 and not 4 and not 8 and not 16)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Invalid max anisotropy: {desc.MaxAnisotropy}. Supported values are: 1, 2, 4, 8, or 16.");
+                                         $"Invalid max anisotropy value '{desc.MaxAnisotropy}'. " +
+                                         "Supported values are: 1, 2, 4, 8, or 16. These values represent the maximum anisotropic filtering level.");
         }
 
         if (desc.MinLod < 0)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "MinLod must be greater than or equal to zero.");
+                                         $"Sampler MinLod ({desc.MinLod}) must be greater than or equal to zero. " +
+                                         "Negative LOD values are not supported.");
         }
 
         if (desc.MaxLod < desc.MinLod)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "MaxLod must be greater than or equal to MinLod.");
+                                         $"Sampler MaxLod ({desc.MaxLod}) must be greater than or equal to MinLod ({desc.MinLod}). " +
+                                         "The LOD range must be valid with MaxLod ≥ MinLod.");
         }
 
         if (desc.LodBias is < -16 or > 16)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "LodBias must be between -16 and 16.");
+                                         $"Sampler LodBias ({desc.LodBias}) must be within the range [-16, 16]. " +
+                                         "This range represents the maximum LOD bias supported by most hardware.");
         }
 
-        ValidateDefinedEnum(desc.BorderColor, "border color");
+        ValidateDefinedEnum(desc.BorderColor, "sampler border color");
     }
 
     public void ValidateResourceLayoutDesc(ResourceLayoutDesc desc)
@@ -257,7 +285,8 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Resource layout elements cannot be null.");
+                                         "Resource layout elements array cannot be null. " +
+                                         "Provide a valid array of resource elements, even if empty.");
 
             return;
         }
@@ -266,20 +295,22 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Resource layout must have at least one element.");
+                                         "Resource layout must have at least one element. " +
+                                         "Define the resources that will be bound to this layout.");
         }
 
         for (int i = 0; i < desc.Elements.Length; i++)
         {
             ResourceElement element = desc.Elements[i];
 
-            ValidateDefinedEnum(element.Type, $"resource element type at index {i}");
+            ValidateDefinedEnum(element.Type, $"resource element type at binding index {i}");
 
             if (element.Count is 0)
             {
                 context.PublishDebugCallback(MessageCategory.System,
                                              MessageSeverity.Error,
-                                             $"Resource element count at index {i} must be greater than zero.");
+                                             $"Resource element at binding index {i} has a count of zero. " +
+                                             "Each element must have a count of at least 1 to represent valid resources.");
             }
         }
     }
@@ -290,7 +321,8 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Resource set must reference a valid resource layout that is not disposed.");
+                                         "Resource set must reference a valid resource layout that is not null and not disposed. " +
+                                         "Ensure the layout exists and has not been disposed before creating the resource set.");
 
             return;
         }
@@ -299,7 +331,8 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Resource set resources cannot be null.");
+                                         "Resource set resources array cannot be null. " +
+                                         "Provide a valid array of resources matching the layout requirements.");
 
             return;
         }
@@ -310,7 +343,8 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Resource set must have exactly {types.Length} resources to match the layout. Provided: {desc.Resources.Length}.");
+                                         $"Resource set has incorrect number of resources. Expected {types.Length} resources based on the layout, " +
+                                         $"but {desc.Resources.Length} were provided. The resource count must exactly match the layout definition.");
 
             return;
         }
@@ -323,7 +357,8 @@ internal class ResourceValidator(GraphicsContext context)
             {
                 context.PublishDebugCallback(MessageCategory.System,
                                              MessageSeverity.Error,
-                                             $"Resource at index {i} is null. All resources must be valid.");
+                                             $"Resource at binding slot {i} is null or disposed. " +
+                                             $"All resources must be valid, non-null, and not disposed. Expected resource type: {types[i]}.");
 
                 continue;
             }
@@ -333,20 +368,22 @@ internal class ResourceValidator(GraphicsContext context)
                 case ResourceType.ConstantBuffer:
                 case ResourceType.StructuredBuffer:
                 case ResourceType.StructuredBufferReadWrite:
-                    if (resource is not IBuffer)
+                    if (resource is not Buffer and not BufferView)
                     {
                         context.PublishDebugCallback(MessageCategory.System,
                                                      MessageSeverity.Error,
-                                                     $"Resource at index {i} is not a valid buffer.");
+                                                     $"Resource at binding slot {i} is not a valid buffer resource. " +
+                                                     $"Expected Buffer or BufferView for resource type '{types[i]}', but got '{resource.GetType().Name}'.");
                     }
                     break;
                 case ResourceType.Texture:
                 case ResourceType.TextureReadWrite:
-                    if (resource is not ITexture)
+                    if (resource is not Texture and not TextureView)
                     {
                         context.PublishDebugCallback(MessageCategory.System,
                                                      MessageSeverity.Error,
-                                                     $"Resource at index {i} is not a valid texture.");
+                                                     $"Resource at binding slot {i} is not a valid texture resource. " +
+                                                     $"Expected Texture or TextureView for resource type '{types[i]}', but got '{resource.GetType().Name}'.");
                     }
                     break;
                 case ResourceType.Sampler:
@@ -354,7 +391,8 @@ internal class ResourceValidator(GraphicsContext context)
                     {
                         context.PublishDebugCallback(MessageCategory.System,
                                                      MessageSeverity.Error,
-                                                     $"Resource at index {i} is not a valid sampler.");
+                                                     $"Resource at binding slot {i} is not a valid sampler. " +
+                                                     $"Expected Sampler for resource type '{types[i]}', but got '{resource.GetType().Name}'.");
                     }
                     break;
                 case ResourceType.AccelerationStructure:
@@ -362,13 +400,15 @@ internal class ResourceValidator(GraphicsContext context)
                     {
                         context.PublishDebugCallback(MessageCategory.System,
                                                      MessageSeverity.Error,
-                                                     $"Resource at index {i} is not a valid acceleration structure.");
+                                                     $"Resource at binding slot {i} is not a valid acceleration structure. " +
+                                                     $"Expected TopLevelAccelerationStructure for resource type '{types[i]}', but got '{resource.GetType().Name}'.");
                     }
                     break;
                 default:
                     context.PublishDebugCallback(MessageCategory.System,
                                                  MessageSeverity.Error,
-                                                 $"Invalid resource type at index {i}: {types[i]}. Supported types are: {string.Join(", ", Enum.GetNames<ResourceType>())}.");
+                                                 $"Unknown resource type '{types[i]}' at binding slot {i}. " +
+                                                 $"Supported resource types are: {string.Join(", ", Enum.GetNames<ResourceType>())}.");
                     break;
             }
         }
@@ -380,7 +420,8 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Frame buffer color targets cannot be null.");
+                                         "Frame buffer color targets array cannot be null. " +
+                                         "Provide a valid array of color targets, even if empty.");
 
             return;
         }
@@ -389,7 +430,8 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Frame buffer must have at least one color target or a depth-stencil target.");
+                                         "Frame buffer must have at least one render target. " +
+                                         "Provide either one or more color targets, or a depth-stencil target, or both.");
 
             return;
         }
@@ -398,12 +440,13 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Frame buffer cannot have more than 8 color targets.");
+                                         $"Frame buffer has too many color targets ({desc.ColorTargets.Length}). " +
+                                         "Maximum supported color targets is 8. This is a hardware limitation on most GPUs.");
         }
 
         for (int i = 0; i < desc.ColorTargets.Length; i++)
         {
-            ValidateFrameBufferAttachment(desc.ColorTargets[i], $"color target at index {i}");
+            ValidateFrameBufferAttachment(desc.ColorTargets[i], $"color target at attachment slot {i}");
         }
 
         if (desc.DepthStencilTarget is not null)
@@ -418,7 +461,8 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Shader bytecode cannot be null.");
+                                         "Shader bytecode cannot be null. " +
+                                         "Provide valid compiled shader bytecode.");
 
             return;
         }
@@ -427,14 +471,16 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Shader bytecode must not be empty.");
+                                         "Shader bytecode is empty. " +
+                                         "Provide valid compiled shader bytecode with non-zero length.");
         }
 
         if (string.IsNullOrEmpty(desc.EntryPoint))
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Shader entry point must not be null or empty.");
+                                         "Shader entry point name is missing. " +
+                                         "Specify the function name that serves as the shader's entry point (e.g., 'main', 'VSMain', etc.).");
         }
 
         ValidateDefinedEnum(desc.Stage, "shader stage");
@@ -450,31 +496,34 @@ internal class ResourceValidator(GraphicsContext context)
             {
                 RasterizerState rasterizerState = renderStates.RasterizerState;
 
-                ValidateDefinedEnum(rasterizerState.CullMode, "cull mode");
+                ValidateDefinedEnum(rasterizerState.CullMode, "rasterizer cull mode");
 
-                ValidateDefinedEnum(rasterizerState.FillMode, "fill mode");
+                ValidateDefinedEnum(rasterizerState.FillMode, "rasterizer fill mode");
 
-                ValidateDefinedEnum(rasterizerState.FrontFace, "front face");
+                ValidateDefinedEnum(rasterizerState.FrontFace, "rasterizer front face winding order");
 
                 if (rasterizerState.DepthBias < 0)
                 {
                     context.PublishDebugCallback(MessageCategory.System,
                                                  MessageSeverity.Error,
-                                                 "Depth bias must be greater than or equal to zero.");
+                                                 $"Rasterizer depth bias ({rasterizerState.DepthBias}) must be greater than or equal to zero. " +
+                                                 "Negative depth bias values are not supported.");
                 }
 
                 if (rasterizerState.DepthBiasClamp < 0)
                 {
                     context.PublishDebugCallback(MessageCategory.System,
                                                  MessageSeverity.Error,
-                                                 "Depth bias clamp must be greater than or equal to zero.");
+                                                 $"Rasterizer depth bias clamp ({rasterizerState.DepthBiasClamp}) must be greater than or equal to zero. " +
+                                                 "This value limits the maximum depth bias applied.");
                 }
 
                 if (rasterizerState.SlopeScaledDepthBias < 0)
                 {
                     context.PublishDebugCallback(MessageCategory.System,
                                                  MessageSeverity.Error,
-                                                 "Slope scaled depth bias must be greater than or equal to zero.");
+                                                 $"Rasterizer slope scaled depth bias ({rasterizerState.SlopeScaledDepthBias}) must be greater than or equal to zero. " +
+                                                 "This value scales the depth bias based on polygon slope.");
                 }
             }
 
@@ -482,22 +531,25 @@ internal class ResourceValidator(GraphicsContext context)
             {
                 DepthStencilState depthStencilState = renderStates.DepthStencilState;
 
-                ValidateDefinedEnum(depthStencilState.DepthFunc, "depth function");
+                ValidateDefinedEnum(depthStencilState.DepthFunc, "depth comparison function");
 
-                ValidateDepthStencilStateOp(depthStencilState.FrontFace, "front face");
+                ValidateDepthStencilStateOp(depthStencilState.FrontFace, "front-facing polygons");
 
-                ValidateDepthStencilStateOp(depthStencilState.BackFace, "back face");
+                ValidateDepthStencilStateOp(depthStencilState.BackFace, "back-facing polygons");
             }
 
             // BlendState
             {
                 BlendState blendState = renderStates.BlendState;
 
-                BlendStateRenderTarget[] renderTargets = blendState.IndependentBlendEnable ? [blendState.RenderTarget0, blendState.RenderTarget1, blendState.RenderTarget2, blendState.RenderTarget3, blendState.RenderTarget4, blendState.RenderTarget5, blendState.RenderTarget6, blendState.RenderTarget7] : [blendState.RenderTarget0];
+                BlendStateRenderTarget[] renderTargets = blendState.IndependentBlendEnable
+                    ? [blendState.RenderTarget0, blendState.RenderTarget1, blendState.RenderTarget2, blendState.RenderTarget3,
+                       blendState.RenderTarget4, blendState.RenderTarget5, blendState.RenderTarget6, blendState.RenderTarget7]
+                    : [blendState.RenderTarget0];
 
                 for (int i = 0; i < renderTargets.Length; i++)
                 {
-                    ValidateBlendStateRenderTarget(renderTargets[i], $"render target at index {i}");
+                    ValidateBlendStateRenderTarget(renderTargets[i], $"blend state render target {i}");
                 }
             }
         }
@@ -510,12 +562,12 @@ internal class ResourceValidator(GraphicsContext context)
 
             if (shaders.Hull is not null)
             {
-                ValidateShader(shaders.Hull, "Hull shader");
+                ValidateShader(shaders.Hull, "Hull (tessellation control) shader");
             }
 
             if (shaders.Domain is not null)
             {
-                ValidateShader(shaders.Domain, "Domain shader");
+                ValidateShader(shaders.Domain, "Domain (tessellation evaluation) shader");
             }
 
             if (shaders.Geometry is not null)
@@ -523,12 +575,15 @@ internal class ResourceValidator(GraphicsContext context)
                 ValidateShader(shaders.Geometry, "Geometry shader");
             }
 
-            ValidateShader(shaders.Pixel, "Pixel shader");
+            ValidateShader(shaders.Pixel, "Pixel (fragment) shader");
         }
 
         if (desc.InputLayouts is null || desc.InputLayouts.Length is 0)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Graphics pipeline must have at least one input layout.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "Graphics pipeline must have at least one input layout. " +
+                                         "Define the vertex input layout that describes how vertex data is organized.");
         }
 
         ValidateResourceLayouts(desc.ResourceLayouts);
@@ -542,7 +597,8 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Compute pipeline must reference a valid shader that is not disposed.");
+                                         "Compute pipeline must reference a valid compute shader that is not null and not disposed. " +
+                                         "Ensure the compute shader exists and has not been disposed.");
         }
 
         ValidateResourceLayouts(desc.ResourceLayouts);
@@ -556,20 +612,21 @@ internal class ResourceValidator(GraphicsContext context)
 
             ValidateShader(shaders.RayGeneration, "Ray generation shader");
 
-            ValidateShaders(shaders.Miss, "Miss shaders");
+            ValidateShaders(shaders.Miss, "Miss shader array");
 
-            ValidateShaders(shaders.AnyHit, "Any-hit shaders");
+            ValidateShaders(shaders.AnyHit, "Any-hit shader array");
 
-            ValidateShaders(shaders.Intersection, "Intersection shaders");
+            ValidateShaders(shaders.Intersection, "Intersection shader array");
 
-            ValidateShaders(shaders.ClosestHit, "Closest-hit shaders");
+            ValidateShaders(shaders.ClosestHit, "Closest-hit shader array");
         }
 
         if (desc.HitGroups is null)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Ray tracing pipeline hit groups cannot be null.");
+                                         "Ray tracing pipeline hit groups array cannot be null. " +
+                                         "Provide a valid array of hit groups that define shader combinations for ray-triangle intersections.");
         }
         else
         {
@@ -583,7 +640,8 @@ internal class ResourceValidator(GraphicsContext context)
                 {
                     context.PublishDebugCallback(MessageCategory.System,
                                                  MessageSeverity.Error,
-                                                 $"Hit group at index {i} must have a non-empty name.");
+                                                 $"Hit group at index {i} has an empty or null name. " +
+                                                 "Each hit group must have a unique, non-empty name for shader table indexing.");
                 }
             }
 
@@ -591,9 +649,14 @@ internal class ResourceValidator(GraphicsContext context)
 
             if (hitGroupNames.Distinct().Count() != hitGroupNames.Length)
             {
+                var duplicates = hitGroupNames.GroupBy(static x => x)
+                                              .Where(static g => g.Count() > 1)
+                                              .Select(static g => g.Key);
+
                 context.PublishDebugCallback(MessageCategory.System,
                                              MessageSeverity.Error,
-                                             "Ray tracing pipeline hit groups must have unique names. Duplicate names found.");
+                                             $"Ray tracing pipeline contains duplicate hit group names: {string.Join(", ", duplicates)}. " +
+                                             "Each hit group must have a unique name for proper shader table addressing.");
             }
         }
 
@@ -603,21 +666,24 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Max trace recursion depth must be less than or equal to 31.");
+                                         $"Max trace recursion depth ({desc.MaxTraceRecursionDepth}) exceeds the maximum supported value of 31. " +
+                                         "This is a hardware limitation for ray tracing recursion depth.");
         }
 
         if (desc.MaxPayloadSizeInBytes % 4 is not 0)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Max payload size in bytes must be a multiple of 4.");
+                                         $"Max payload size ({desc.MaxPayloadSizeInBytes} bytes) must be a multiple of 4. " +
+                                         "Ray tracing payloads must be aligned to 4-byte boundaries.");
         }
 
         if (desc.MaxAttributeSizeInBytes % 4 is not 0 or > 32)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Max attribute size in bytes must be a multiple of 4 and less than or equal to 32.");
+                                         $"Max attribute size ({desc.MaxAttributeSizeInBytes} bytes) must be a multiple of 4 and not exceed 32 bytes. " +
+                                         "This is a hardware limitation for ray-triangle intersection attributes.");
         }
     }
 
@@ -629,60 +695,52 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Surface handles cannot be null.");
+                                         "Surface handles array cannot be null. " +
+                                         "Provide the platform-specific window/surface handles required for presentation.");
 
             return;
         }
 
-        if (surface.Type is SurfaceType.Win32 && surface.Handles.Length is not 1)
+        string expectedHandles = surface.Type switch
+        {
+            SurfaceType.Win32 => "1 handle (HWND)",
+            SurfaceType.Wayland => "2 handles (display, surface)",
+            SurfaceType.Xlib => "2 handles (display, window)",
+            SurfaceType.Android => "1 handle (ANativeWindow)",
+            SurfaceType.IOS => "1 handle (UIView/CAMetalLayer)",
+            SurfaceType.MacOS => "1 handle (NSView/CAMetalLayer)",
+            _ => "unknown number of handles"
+        };
+
+        int expectedCount = surface.Type switch
+        {
+            SurfaceType.Win32 or SurfaceType.Android or SurfaceType.IOS or SurfaceType.MacOS => 1,
+            SurfaceType.Wayland or SurfaceType.Xlib => 2,
+            _ => -1
+        };
+
+        if (expectedCount != -1 && surface.Handles.Length != expectedCount)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Win32 surface must have exactly one handle (HWND).");
-        }
-        else if (surface.Type is SurfaceType.Wayland && surface.Handles.Length is not 2)
-        {
-            context.PublishDebugCallback(MessageCategory.System,
-                                         MessageSeverity.Error,
-                                         "Wayland surface must have exactly two handles (display and surface).");
-        }
-        else if (surface.Type is SurfaceType.Xlib && surface.Handles.Length is not 2)
-        {
-            context.PublishDebugCallback(MessageCategory.System,
-                                         MessageSeverity.Error,
-                                         "Xlib surface must have exactly two handles (display and window).");
-        }
-        else if (surface.Type is SurfaceType.Android && surface.Handles.Length is not 1)
-        {
-            context.PublishDebugCallback(MessageCategory.System,
-                                         MessageSeverity.Error,
-                                         "Android surface must have exactly one handle (native window).");
-        }
-        else if (surface.Type is SurfaceType.IOS && surface.Handles.Length is not 1)
-        {
-            context.PublishDebugCallback(MessageCategory.System,
-                                         MessageSeverity.Error,
-                                         "iOS surface must have exactly one handle (view).");
-        }
-        else if (surface.Type is SurfaceType.MacOS && surface.Handles.Length is not 1)
-        {
-            context.PublishDebugCallback(MessageCategory.System,
-                                         MessageSeverity.Error,
-                                         "MacOS surface must have exactly one handle (view).");
+                                         $"Surface type '{surface.Type}' requires exactly {expectedHandles}, but {surface.Handles.Length} were provided. " +
+                                         "Ensure you provide the correct number of platform-specific handles.");
         }
 
         if (surface.Handles.Any(static item => item is 0))
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Surface handles cannot contain zero values.");
+                                         "Surface handles contain null (zero) values. " +
+                                         "All platform handles must be valid, non-zero pointers.");
         }
 
         if (surface.Width is 0 || surface.Height is 0)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Surface width and height must be greater than zero.");
+                                         $"Surface dimensions are invalid. Width ({surface.Width}) and height ({surface.Height}) must both be greater than zero. " +
+                                         "Specify valid window/surface dimensions.");
         }
     }
 
@@ -692,18 +750,20 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Attachment '{name}' is invalid. It must reference a valid texture that is not disposed.");
+                                         $"Frame buffer {name} references an invalid texture. " +
+                                         "The texture must be valid, non-null, and not disposed.");
 
             return;
         }
 
         ObtainTextureValues(attachment.Target, out TextureType type, out uint layers, out uint mipLevels, name);
 
-        if (type is not TextureType.Texture2D or TextureType.Texture2DArray)
+        if (type is not TextureType.Texture2D and not TextureType.Texture2DArray)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Invalid texture type for frame buffer attachment '{name}': {type}. Only Texture2D and Texture2DArray are supported.");
+                                         $"Frame buffer {name} has invalid texture type '{type}'. " +
+                                         "Only Texture2D and Texture2DArray are supported as frame buffer attachments.");
         }
 
         ValidateTextureSlice(type, layers, mipLevels, attachment.Slice, name);
@@ -711,26 +771,26 @@ internal class ResourceValidator(GraphicsContext context)
 
     private void ValidateDepthStencilStateOp(DepthStencilStateOp stateOp, string name)
     {
-        ValidateDefinedEnum(stateOp.StencilFailOp, $"{name} stencil fail operation");
+        ValidateDefinedEnum(stateOp.StencilFailOp, $"stencil fail operation for {name}");
 
-        ValidateDefinedEnum(stateOp.StencilDepthFailOp, $"{name} stencil depth fail operation");
+        ValidateDefinedEnum(stateOp.StencilDepthFailOp, $"stencil depth fail operation for {name}");
 
-        ValidateDefinedEnum(stateOp.StencilPassOp, $"{name} stencil pass operation");
+        ValidateDefinedEnum(stateOp.StencilPassOp, $"stencil pass operation for {name}");
 
-        ValidateDefinedEnum(stateOp.StencilFunc, $"{name} stencil function");
+        ValidateDefinedEnum(stateOp.StencilFunc, $"stencil comparison function for {name}");
     }
 
     private void ValidateBlendStateRenderTarget(BlendStateRenderTarget renderTarget, string name)
     {
-        ValidateDefinedEnum(renderTarget.SrcBlend, $"{name} source blend");
+        ValidateDefinedEnum(renderTarget.SrcBlend, $"{name} source color blend factor");
 
-        ValidateDefinedEnum(renderTarget.DestBlend, $"{name} destination blend");
+        ValidateDefinedEnum(renderTarget.DestBlend, $"{name} destination color blend factor");
 
-        ValidateDefinedEnum(renderTarget.BlendOp, $"{name} blend operation");
+        ValidateDefinedEnum(renderTarget.BlendOp, $"{name} color blend operation");
 
-        ValidateDefinedEnum(renderTarget.SrcBlendAlpha, $"{name} source alpha blend");
+        ValidateDefinedEnum(renderTarget.SrcBlendAlpha, $"{name} source alpha blend factor");
 
-        ValidateDefinedEnum(renderTarget.DestBlendAlpha, $"{name} destination alpha blend");
+        ValidateDefinedEnum(renderTarget.DestBlendAlpha, $"{name} destination alpha blend factor");
 
         ValidateDefinedEnum(renderTarget.BlendOpAlpha, $"{name} alpha blend operation");
     }
@@ -741,7 +801,8 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"{name} cannot be null.");
+                                         $"{name} cannot be null. " +
+                                         "Provide a valid array of shaders, even if empty.");
 
             return;
         }
@@ -758,7 +819,8 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Resource layouts cannot be null.");
+                                         "Pipeline resource layouts array cannot be null. " +
+                                         "Provide a valid array of resource layouts that define the pipeline's resource bindings.");
 
             return;
         }
@@ -771,7 +833,8 @@ internal class ResourceValidator(GraphicsContext context)
             {
                 context.PublishDebugCallback(MessageCategory.System,
                                              MessageSeverity.Error,
-                                             $"Resource layout at index {i} must reference a valid resource layout that is not disposed.");
+                                             $"Resource layout at set index {i} is null or disposed. " +
+                                             $"All resource layouts must be valid, non-null, and not disposed.");
             }
         }
     }
@@ -782,7 +845,8 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Output color attachments cannot be null.");
+                                         "Pipeline output color attachments array cannot be null. " +
+                                         "Provide a valid array of color attachment formats, even if empty.");
 
             return;
         }
@@ -791,7 +855,8 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Output must have at least one color attachment or a depth-stencil attachment.");
+                                         "Pipeline output must have at least one render target. " +
+                                         "Specify either one or more color attachment formats, or a depth-stencil format, or both.");
 
             return;
         }
@@ -800,14 +865,16 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         "Output cannot have more than 8 color attachments.");
+                                         $"Pipeline output has too many color attachments ({output.ColorAttachments.Length}). " +
+                                         "Maximum supported color attachments is 8. This is a hardware limitation on most GPUs.");
         }
 
         if (output.DepthStencilAttachment is not null && !depthStencilFormats.Contains(output.DepthStencilAttachment.Value))
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Invalid depth-stencil attachment format: {output.DepthStencilAttachment.Value}. Supported formats are: {string.Join(", ", depthStencilFormats.Select(static item => item.ToString()))}.");
+                                         $"Pipeline output depth-stencil format '{output.DepthStencilAttachment.Value}' is not supported. " +
+                                         $"Supported depth-stencil formats are: {string.Join(", ", depthStencilFormats.Select(static item => item.ToString()))}.");
         }
     }
 
@@ -818,7 +885,8 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Invalid {name}: {value}. Supported values are: {string.Join(", ", Enum.GetNames<TEnum>())}.");
+                                         $"Invalid {name} value '{value}'. " +
+                                         $"Valid values are: {string.Join(", ", Enum.GetNames<TEnum>())}.");
         }
     }
 
@@ -828,7 +896,8 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"{name} must reference a valid shader that is not disposed.");
+                                         $"{name} is required but is null or disposed. " +
+                                         "Ensure the shader is created and not disposed before using it in a pipeline.");
         }
     }
     #endregion
@@ -860,7 +929,8 @@ internal class ResourceValidator(GraphicsContext context)
 
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Invalid texture type for slice validation in {name}. Expected Texture or TextureView.");
+                                         $"Unexpected texture type in {name}. " +
+                                         $"Expected Texture or TextureView, but got '{iTexture.GetType().Name}'.");
         }
     }
 
@@ -876,14 +946,16 @@ internal class ResourceValidator(GraphicsContext context)
             {
                 context.PublishDebugCallback(MessageCategory.System,
                                              MessageSeverity.Error,
-                                             $"Invalid face index: {slice.Face} for {name} with texture type {type}. It must be less than 6.");
+                                             $"Invalid cube face index {slice.Face} for {name}. " +
+                                             $"Cube textures have 6 faces (0-5). Valid range is 0 to 5.");
             }
         }
         else if (slice.Face is not 0)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Invalid face index: {slice.Face} for {name} with texture type {type}. Only TextureCube and TextureCubeArray support multiple faces.");
+                                         $"Invalid face index {slice.Face} for {name} with texture type '{type}'. " +
+                                         "Only TextureCube and TextureCubeArray support multiple faces. Use Face = 0 for other texture types.");
         }
 
         if (arrayTextureTypes.Contains(type))
@@ -892,21 +964,24 @@ internal class ResourceValidator(GraphicsContext context)
             {
                 context.PublishDebugCallback(MessageCategory.System,
                                              MessageSeverity.Error,
-                                             $"Invalid layer index: {slice.Layer} for {name} with texture type {type}. It must be less than the number of layers ({layers}).");
+                                             $"Invalid layer index {slice.Layer} for {name}. " +
+                                             $"The texture has {layers} layers. Valid range is 0 to {layers - 1}.");
             }
         }
         else if (slice.Layer is not 0)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Invalid layer index: {slice.Layer} for {name} with texture type {type}. Only array textures support multiple layers.");
+                                         $"Invalid layer index {slice.Layer} for {name} with texture type '{type}'. " +
+                                         "Only array texture types support multiple layers. Use Layer = 0 for non-array textures.");
         }
 
         if (slice.MipLevel >= mipLevels)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Invalid mip level: {slice.MipLevel} for {name} with texture type {type}. It must be less than the number of mip levels ({mipLevels}).");
+                                         $"Invalid mip level {slice.MipLevel} for {name}. " +
+                                         $"The texture has {mipLevels} mip levels. Valid range is 0 to {mipLevels - 1}.");
         }
     }
     #endregion

--- a/sources/Zenith.NET/ResourceValidator.cs
+++ b/sources/Zenith.NET/ResourceValidator.cs
@@ -401,9 +401,58 @@ internal class ResourceValidator(GraphicsContext context)
         ValidateTextureSlice(attachment.Target, attachment.Slice);
     }
 
-    private void ValidateTextureSlice(ITexture texture, TextureSlice slice)
+    private void ValidateTextureSlice(ITexture iTexture, TextureSlice slice)
     {
         TextureType type;
+        uint layers;
+        uint mipLevels;
 
+        if (iTexture is Texture texture)
+        {
+            type = texture.Desc.Type;
+            layers = texture.Desc.Layers;
+            mipLevels = texture.Desc.MipLevels;
+        }
+        else if (iTexture is TextureView textureView)
+        {
+            type = textureView.Desc.Texture.Desc.Type;
+            layers = textureView.Desc.LayerCount;
+            mipLevels = textureView.Desc.MipLevelCount;
+        }
+        else
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Invalid texture type for slice validation. Expected Texture or TextureView.");
+
+            return;
+        }
+
+        if (type is TextureType.TextureCube or TextureType.TextureCubeArray)
+        {
+            if (slice.Face >= 6)
+            {
+                context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid face index: {slice.Face}. It must be between 0 and 5 for cube textures.");
+            }
+        }
+        else if (slice.Face is not 0)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid face index: {slice.Face}. It must be 0 for non-cube textures.");
+        }
+
+        if (type is TextureType.Texture1DArray or TextureType.Texture2DArray or TextureType.TextureCubeArray)
+        {
+            if (slice.Layer >= layers)
+            {
+                context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid layer index: {slice.Layer}. It must be less than the number of layers ({layers}) for array textures.");
+            }
+        }
+        else if (slice.Layer is not 0)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid layer index: {slice.Layer}. It must be 0 for non-array textures.");
+        }
+
+        if (slice.MipLevel >= mipLevels)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid mip level: {slice.MipLevel}. It must be less than the number of mip levels ({mipLevels}).");
+        }
     }
 }

--- a/sources/Zenith.NET/ResourceValidator.cs
+++ b/sources/Zenith.NET/ResourceValidator.cs
@@ -79,8 +79,6 @@ internal class ResourceValidator(GraphicsContext context)
         if (!Enum.IsDefined(desc.Type))
         {
             context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid texture type: {desc.Type}. Supported types are: {string.Join(", ", Enum.GetNames<TextureType>())}.");
-
-            return;
         }
 
         if (desc.Type is TextureType.Texture1D or TextureType.Texture1DArray && desc.Width is 0)
@@ -198,13 +196,108 @@ internal class ResourceValidator(GraphicsContext context)
         }
     }
 
+    public void ValidateResourceLayoutDesc(ResourceLayoutDesc desc)
+    {
+        if (desc.Elements is null || desc.Elements.Length is 0)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Resource layout must have at least one element.");
+
+            return;
+        }
+
+        for (int i = 0; i < desc.Elements.Length; i++)
+        {
+            ResourceElement element = desc.Elements[i];
+
+            if (!Enum.IsDefined(element.Type))
+            {
+                context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid resource element type at index {i}: {element.Type}. Supported types are: {string.Join(", ", Enum.GetNames<ResourceType>())}.");
+            }
+
+            if (element.Count is 0)
+            {
+                context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Resource element count at index {i} must be greater than zero.");
+            }
+        }
+    }
+
+    public void ValidateResourceSetDesc(ResourceSetDesc desc)
+    {
+        if (desc.Layout?.IsDisposed is not false)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Resource set must reference a valid resource layout that is not disposed.");
+
+            return;
+        }
+
+        if (desc.Resources is null || desc.Resources.Length is 0)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Resource set must have at least one resource.");
+
+            return;
+        }
+
+        ResourceType[] types = [.. desc.Layout.Desc.Elements.SelectMany(static item => Enumerable.Repeat(item.Type, (int)item.Count))];
+
+        if (desc.Resources.Length != types.Length)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Resource set must have exactly {types.Length} resources to match the layout. Provided: {desc.Resources.Length}.");
+
+            return;
+        }
+
+        for (int i = 0; i < desc.Resources.Length; i++)
+        {
+            IBindableResource? resource = desc.Resources[i];
+
+            if (resource?.IsDisposed is not false)
+            {
+                context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Resource at index {i} is null. All resources must be valid.");
+
+                continue;
+            }
+
+            switch (types[i])
+            {
+                case ResourceType.ConstantBuffer:
+                case ResourceType.StructuredBuffer:
+                case ResourceType.StructuredBufferReadWrite:
+                    if (resource is not IBuffer)
+                    {
+                        context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Resource at index {i} is not a valid buffer.");
+                    }
+                    break;
+                case ResourceType.Texture:
+                case ResourceType.TextureReadWrite:
+                    if (resource is not ITexture)
+                    {
+                        context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Resource at index {i} is not a valid texture.");
+                    }
+                    break;
+                case ResourceType.Sampler:
+                    if (resource is not Sampler)
+                    {
+                        context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Resource at index {i} is not a valid sampler.");
+                    }
+                    break;
+                case ResourceType.AccelerationStructure:
+                    if (resource is not TopLevelAccelerationStructure)
+                    {
+                        context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Resource at index {i} is not a valid acceleration structure.");
+                    }
+                    break;
+                default:
+                    context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid resource type at index {i}: {types[i]}. Supported types are: {string.Join(", ", Enum.GetNames<ResourceType>())}.");
+                    break;
+            }
+        }
+    }
+
     private void ValidateSurface(Surface surface)
     {
         if (!Enum.IsDefined(surface.Type))
         {
             context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid surface type: {surface.Type}. Supported types are: {string.Join(", ", Enum.GetNames<SurfaceType>())}.");
-
-            return;
         }
 
         if (surface.Handles is null)

--- a/sources/Zenith.NET/ResourceValidator.cs
+++ b/sources/Zenith.NET/ResourceValidator.cs
@@ -1,6 +1,6 @@
 ﻿namespace Zenith.NET;
 
-internal class Validator(GraphicsContext context)
+internal class ResourceValidator(GraphicsContext context)
 {
     private static readonly PixelFormat[] swapChainFormats =
     [

--- a/sources/Zenith.NET/ResourceValidator.cs
+++ b/sources/Zenith.NET/ResourceValidator.cs
@@ -198,11 +198,16 @@ internal class ResourceValidator(GraphicsContext context)
 
     public void ValidateResourceLayoutDesc(ResourceLayoutDesc desc)
     {
-        if (desc.Elements is null || desc.Elements.Length is 0)
+        if (desc.Elements is null)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Resource layout must have at least one element.");
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Resource layout elements cannot be null.");
 
             return;
+        }
+
+        if (desc.Elements.Length is 0)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Resource layout must have at least one element.");
         }
 
         for (int i = 0; i < desc.Elements.Length; i++)
@@ -230,9 +235,9 @@ internal class ResourceValidator(GraphicsContext context)
             return;
         }
 
-        if (desc.Resources is null || desc.Resources.Length is 0)
+        if (desc.Resources is null)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Resource set must have at least one resource.");
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Resource set resources cannot be null.");
 
             return;
         }
@@ -293,6 +298,38 @@ internal class ResourceValidator(GraphicsContext context)
         }
     }
 
+    public void ValidateFrameBufferDesc(FrameBufferDesc desc)
+    {
+        if (desc.ColorTargets is null)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Frame buffer color targets cannot be null.");
+
+            return;
+        }
+
+        if (desc.ColorTargets.Length is 0 && desc.DepthStencilTarget is null)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Frame buffer must have at least one color target or a depth-stencil target.");
+
+            return;
+        }
+
+        if (desc.ColorTargets.Length > 8)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Frame buffer cannot have more than 8 color targets.");
+        }
+
+        foreach (FrameBufferAttachment frameBufferAttachment in desc.ColorTargets)
+        {
+            ValidateFrameBufferAttachment(frameBufferAttachment);
+        }
+
+        if (desc.DepthStencilTarget is not null)
+        {
+            ValidateFrameBufferAttachment(desc.DepthStencilTarget.Value);
+        }
+    }
+
     private void ValidateSurface(Surface surface)
     {
         if (!Enum.IsDefined(surface.Type))
@@ -341,5 +378,22 @@ internal class ResourceValidator(GraphicsContext context)
         {
             context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Surface width and height must be greater than zero.");
         }
+    }
+
+    private void ValidateFrameBufferAttachment(FrameBufferAttachment attachment)
+    {
+        if (attachment.Target?.IsDisposed is not false)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Frame buffer attachment must reference a valid texture that is not disposed.");
+
+            return;
+        }
+
+        ValidateTextureSlice(attachment.Target, attachment.Slice);
+    }
+
+    private void ValidateTextureSlice(ITexture texture, TextureSlice slice)
+    {
+        throw new NotImplementedException("Texture slice validation is not implemented yet. This method should check if the slice parameters are valid for the given texture type and dimensions.");
     }
 }

--- a/sources/Zenith.NET/ResourceValidator.cs
+++ b/sources/Zenith.NET/ResourceValidator.cs
@@ -333,20 +333,20 @@ internal class ResourceValidator(GraphicsContext context)
                 case ResourceType.ConstantBuffer:
                 case ResourceType.StructuredBuffer:
                 case ResourceType.StructuredBufferReadWrite:
-                    if (resource is not IBuffer)
+                    if (resource is not Buffer or BufferView)
                     {
                         context.PublishDebugCallback(MessageCategory.System,
                                                      MessageSeverity.Error,
-                                                     $"Resource at index {i} must be a buffer for resource type '{types[i]}'.");
+                                                     $"Resource at index {i} must be a buffer or buffer view for resource type '{types[i]}'.");
                     }
                     break;
                 case ResourceType.Texture:
                 case ResourceType.TextureReadWrite:
-                    if (resource is not ITexture)
+                    if (resource is not Texture or TextureView)
                     {
                         context.PublishDebugCallback(MessageCategory.System,
                                                      MessageSeverity.Error,
-                                                     $"Resource at index {i} must be a texture for resource type '{types[i]}'.");
+                                                     $"Resource at index {i} must be a texture or texture view for resource type '{types[i]}'.");
                     }
                     break;
                 case ResourceType.Sampler:

--- a/sources/Zenith.NET/ResourceValidator.cs
+++ b/sources/Zenith.NET/ResourceValidator.cs
@@ -32,6 +32,49 @@ internal class ResourceValidator(GraphicsContext context)
         }
     }
 
+    public void ValidateBufferDesc(BufferDesc desc)
+    {
+        if (desc.SizeInBytes is 0)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Buffer size must be greater than zero.");
+        }
+
+        if (desc.StrideInBytes is 0)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Warning, "Buffer stride is zero. This may lead to unexpected behavior, especially when using structured buffers. Consider setting a non-zero stride.");
+        }
+
+        if (desc.Flags is BufferUsageFlags.None)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Buffer usage flags cannot be None. At least one flag must be set.");
+        }
+    }
+
+    public void ValidateBufferViewDesc(BufferViewDesc desc)
+    {
+        if (desc.Buffer?.IsDisposed is not false)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Buffer view must reference a valid buffer that is not disposed.");
+        }
+        else
+        {
+            if (desc.OffsetInBytes + desc.SizeInBytes > desc.Buffer.Desc.SizeInBytes)
+            {
+                context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Buffer view size exceeds the buffer size. Ensure that OffsetInBytes + SizeInBytes does not exceed the buffer's SizeInBytes.");
+            }
+
+            if (desc.SizeInBytes is 0)
+            {
+                context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Buffer view size must be greater than zero.");
+            }
+
+            if (desc.SizeInBytes % desc.Buffer.Desc.StrideInBytes is not 0)
+            {
+                context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Warning, "Buffer view size is not a multiple of the buffer's stride. This may lead to unexpected behavior, especially when using structured buffers.");
+            }
+        }
+    }
+
     private void ValidateSurface(Surface surface)
     {
         if (!Enum.IsDefined(surface.Type))

--- a/sources/Zenith.NET/ResourceValidator.cs
+++ b/sources/Zenith.NET/ResourceValidator.cs
@@ -30,12 +30,16 @@ internal class ResourceValidator(GraphicsContext context)
 
         if (!swapChainFormats.Contains(desc.ColorTargetFormat))
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid color target format: {desc.ColorTargetFormat}. Supported formats are: {string.Join(", ", swapChainFormats.Select(static item => item.ToString()))}.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         $"Invalid color target format: {desc.ColorTargetFormat}. Supported formats are: {string.Join(", ", swapChainFormats.Select(static item => item.ToString()))}.");
         }
 
         if (desc.DepthStencilTargetFormat.HasValue && !depthStencilFormats.Contains(desc.DepthStencilTargetFormat.Value))
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid depth-stencil target format: {desc.DepthStencilTargetFormat.Value}. Supported formats are: {string.Join(", ", depthStencilFormats.Select(static item => item.ToString()))}.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         $"Invalid depth-stencil target format: {desc.DepthStencilTargetFormat.Value}. Supported formats are: {string.Join(", ", depthStencilFormats.Select(static item => item.ToString()))}.");
         }
     }
 
@@ -43,12 +47,16 @@ internal class ResourceValidator(GraphicsContext context)
     {
         if (desc.SizeInBytes is 0)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Buffer size must be greater than zero.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "Buffer size must be greater than zero.");
         }
 
         if (desc.StrideInBytes is 0)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Warning, "Buffer stride is zero. This may lead to unexpected behavior, especially when using structured buffers. Consider setting a non-zero stride.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Warning,
+                                         "Buffer stride is zero. This may lead to unexpected behavior, especially when using structured buffers. Consider setting a non-zero stride.");
         }
     }
 
@@ -56,28 +64,38 @@ internal class ResourceValidator(GraphicsContext context)
     {
         if (desc.Buffer?.IsDisposed is not false)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Buffer view must reference a valid buffer that is not disposed.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "Buffer view must reference a valid buffer that is not disposed.");
 
             return;
         }
 
         if (desc.OffsetInBytes >= desc.Buffer.Desc.SizeInBytes)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid offset: {desc.OffsetInBytes}. It must be less than the buffer's size ({desc.Buffer.Desc.SizeInBytes}).");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         $"Invalid offset: {desc.OffsetInBytes}. It must be less than the buffer's size ({desc.Buffer.Desc.SizeInBytes}).");
         }
 
         if (desc.SizeInBytes is 0)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Buffer view size must be greater than zero.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "Buffer view size must be greater than zero.");
         }
         else if (desc.OffsetInBytes + desc.SizeInBytes > desc.Buffer.Desc.SizeInBytes)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Buffer view size exceeds the buffer's size. Ensure that OffsetInBytes + SizeInBytes does not exceed the buffer's SizeInBytes ({desc.Buffer.Desc.SizeInBytes}).");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         $"Buffer view size exceeds the buffer's size. Ensure that OffsetInBytes + SizeInBytes does not exceed the buffer's SizeInBytes ({desc.Buffer.Desc.SizeInBytes}).");
         }
 
         if (desc.StrideInBytes is 0)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Warning, "Buffer view stride is zero. This may lead to unexpected behavior, especially when using structured buffers. Consider setting a non-zero stride.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Warning,
+                                         "Buffer view stride is zero. This may lead to unexpected behavior, especially when using structured buffers. Consider setting a non-zero stride.");
         }
     }
 
@@ -89,36 +107,50 @@ internal class ResourceValidator(GraphicsContext context)
 
         if (desc.Type is TextureType.Texture1D or TextureType.Texture1DArray && desc.Width is 0)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Texture width must be greater than zero for 1D textures.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "Texture width must be greater than zero for 1D textures.");
         }
         else if (desc.Type is TextureType.Texture2D or TextureType.Texture2DArray && (desc.Width is 0 || desc.Height is 0))
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Texture width and height must be greater than zero for 2D textures.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "Texture width and height must be greater than zero for 2D textures.");
         }
         else if (desc.Type is TextureType.Texture3D && (desc.Width is 0 || desc.Height is 0 || desc.Depth is 0))
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Texture width, height, and depth must be greater than zero for 3D textures.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "Texture width, height, and depth must be greater than zero for 3D textures.");
         }
         else if (desc.Type is TextureType.TextureCube or TextureType.TextureCubeArray && (desc.Width is 0 || desc.Height is 0 || desc.Width != desc.Height))
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Texture width and height must be equal and greater than zero for cube textures.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "Texture width and height must be equal and greater than zero for cube textures.");
         }
 
         if (arrayTextureTypes.Contains(desc.Type))
         {
             if (desc.Layers is 0)
             {
-                context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Texture layers must be greater than zero.");
+                context.PublishDebugCallback(MessageCategory.System,
+                                             MessageSeverity.Error,
+                                             "Texture layers must be greater than zero.");
             }
         }
         else if (desc.Layers is not 1)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Texture layers must be 1 for non-array textures.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "Texture layers must be 1 for non-array textures.");
         }
 
         if (desc.MipLevels is 0)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Texture mip levels must be greater than zero.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "Texture mip levels must be greater than zero.");
         }
 
         ValidateDefinedEnum(desc.SampleCount, "sample count");
@@ -128,37 +160,51 @@ internal class ResourceValidator(GraphicsContext context)
     {
         if (desc.Texture?.IsDisposed is not false)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Texture view must reference a valid texture that is not disposed.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "Texture view must reference a valid texture that is not disposed.");
 
             return;
         }
 
         if (desc.FirstLayer >= desc.Texture.Desc.Layers)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid first layer: {desc.FirstLayer}. It must be less than the texture's layers ({desc.Texture.Desc.Layers}).");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         $"Invalid first layer: {desc.FirstLayer}. It must be less than the texture's layers ({desc.Texture.Desc.Layers}).");
         }
 
         if (desc.LayerCount is 0)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Texture view layer count must be greater than zero.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "Texture view layer count must be greater than zero.");
         }
         else if (desc.FirstLayer + desc.LayerCount > desc.Texture.Desc.Layers)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Texture view layer count exceeds the texture's layers. Ensure that FirstLayer + LayerCount does not exceed the texture's Layers ({desc.Texture.Desc.Layers}).");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         $"Texture view layer count exceeds the texture's layers. Ensure that FirstLayer + LayerCount does not exceed the texture's Layers ({desc.Texture.Desc.Layers}).");
         }
 
         if (desc.FirstMipLevel >= desc.Texture.Desc.MipLevels)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid first mip level: {desc.FirstMipLevel}. It must be less than the texture's mip levels ({desc.Texture.Desc.MipLevels}).");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         $"Invalid first mip level: {desc.FirstMipLevel}. It must be less than the texture's mip levels ({desc.Texture.Desc.MipLevels}).");
         }
 
         if (desc.MipLevelCount is 0)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Texture view mip level count must be greater than zero.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "Texture view mip level count must be greater than zero.");
         }
         else if (desc.FirstMipLevel + desc.MipLevelCount > desc.Texture.Desc.MipLevels)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Texture view mip level count exceeds the texture's mip levels. Ensure that FirstMipLevel + MipLevelCount does not exceed the texture's MipLevels ({desc.Texture.Desc.MipLevels}).");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         $"Texture view mip level count exceeds the texture's mip levels. Ensure that FirstMipLevel + MipLevelCount does not exceed the texture's MipLevels ({desc.Texture.Desc.MipLevels}).");
         }
     }
 
@@ -176,22 +222,30 @@ internal class ResourceValidator(GraphicsContext context)
 
         if (desc.MaxAnisotropy is not 1 and not 2 and not 4 and not 8 and not 16)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid max anisotropy: {desc.MaxAnisotropy}. Supported values are: 1, 2, 4, 8, or 16.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         $"Invalid max anisotropy: {desc.MaxAnisotropy}. Supported values are: 1, 2, 4, 8, or 16.");
         }
 
         if (desc.MinLod < 0)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "MinLod must be greater than or equal to zero.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "MinLod must be greater than or equal to zero.");
         }
 
         if (desc.MaxLod < desc.MinLod)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "MaxLod must be greater than or equal to MinLod.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "MaxLod must be greater than or equal to MinLod.");
         }
 
         if (desc.LodBias is < -16 or > 16)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "LodBias must be between -16 and 16.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "LodBias must be between -16 and 16.");
         }
 
         ValidateDefinedEnum(desc.BorderColor, "border color");
@@ -201,14 +255,18 @@ internal class ResourceValidator(GraphicsContext context)
     {
         if (desc.Elements is null)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Resource layout elements cannot be null.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "Resource layout elements cannot be null.");
 
             return;
         }
 
         if (desc.Elements.Length is 0)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Resource layout must have at least one element.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "Resource layout must have at least one element.");
         }
 
         for (int i = 0; i < desc.Elements.Length; i++)
@@ -219,7 +277,9 @@ internal class ResourceValidator(GraphicsContext context)
 
             if (element.Count is 0)
             {
-                context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Resource element count at index {i} must be greater than zero.");
+                context.PublishDebugCallback(MessageCategory.System,
+                                             MessageSeverity.Error,
+                                             $"Resource element count at index {i} must be greater than zero.");
             }
         }
     }
@@ -228,14 +288,18 @@ internal class ResourceValidator(GraphicsContext context)
     {
         if (desc.Layout?.IsDisposed is not false)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Resource set must reference a valid resource layout that is not disposed.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "Resource set must reference a valid resource layout that is not disposed.");
 
             return;
         }
 
         if (desc.Resources is null)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Resource set resources cannot be null.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "Resource set resources cannot be null.");
 
             return;
         }
@@ -244,7 +308,9 @@ internal class ResourceValidator(GraphicsContext context)
 
         if (desc.Resources.Length != types.Length)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Resource set must have exactly {types.Length} resources to match the layout. Provided: {desc.Resources.Length}.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         $"Resource set must have exactly {types.Length} resources to match the layout. Provided: {desc.Resources.Length}.");
 
             return;
         }
@@ -255,7 +321,9 @@ internal class ResourceValidator(GraphicsContext context)
 
             if (resource?.IsDisposed is not false)
             {
-                context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Resource at index {i} is null. All resources must be valid.");
+                context.PublishDebugCallback(MessageCategory.System,
+                                             MessageSeverity.Error,
+                                             $"Resource at index {i} is null. All resources must be valid.");
 
                 continue;
             }
@@ -267,30 +335,40 @@ internal class ResourceValidator(GraphicsContext context)
                 case ResourceType.StructuredBufferReadWrite:
                     if (resource is not IBuffer)
                     {
-                        context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Resource at index {i} is not a valid buffer.");
+                        context.PublishDebugCallback(MessageCategory.System,
+                                                     MessageSeverity.Error,
+                                                     $"Resource at index {i} is not a valid buffer.");
                     }
                     break;
                 case ResourceType.Texture:
                 case ResourceType.TextureReadWrite:
                     if (resource is not ITexture)
                     {
-                        context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Resource at index {i} is not a valid texture.");
+                        context.PublishDebugCallback(MessageCategory.System,
+                                                     MessageSeverity.Error,
+                                                     $"Resource at index {i} is not a valid texture.");
                     }
                     break;
                 case ResourceType.Sampler:
                     if (resource is not Sampler)
                     {
-                        context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Resource at index {i} is not a valid sampler.");
+                        context.PublishDebugCallback(MessageCategory.System,
+                                                     MessageSeverity.Error,
+                                                     $"Resource at index {i} is not a valid sampler.");
                     }
                     break;
                 case ResourceType.AccelerationStructure:
                     if (resource is not TopLevelAccelerationStructure)
                     {
-                        context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Resource at index {i} is not a valid acceleration structure.");
+                        context.PublishDebugCallback(MessageCategory.System,
+                                                     MessageSeverity.Error,
+                                                     $"Resource at index {i} is not a valid acceleration structure.");
                     }
                     break;
                 default:
-                    context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid resource type at index {i}: {types[i]}. Supported types are: {string.Join(", ", Enum.GetNames<ResourceType>())}.");
+                    context.PublishDebugCallback(MessageCategory.System,
+                                                 MessageSeverity.Error,
+                                                 $"Invalid resource type at index {i}: {types[i]}. Supported types are: {string.Join(", ", Enum.GetNames<ResourceType>())}.");
                     break;
             }
         }
@@ -300,21 +378,27 @@ internal class ResourceValidator(GraphicsContext context)
     {
         if (desc.ColorTargets is null)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Frame buffer color targets cannot be null.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "Frame buffer color targets cannot be null.");
 
             return;
         }
 
         if (desc.ColorTargets.Length is 0 && desc.DepthStencilTarget is null)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Frame buffer must have at least one color target or a depth-stencil target.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "Frame buffer must have at least one color target or a depth-stencil target.");
 
             return;
         }
 
         if (desc.ColorTargets.Length > 8)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Frame buffer cannot have more than 8 color targets.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "Frame buffer cannot have more than 8 color targets.");
         }
 
         for (int i = 0; i < desc.ColorTargets.Length; i++)
@@ -332,19 +416,25 @@ internal class ResourceValidator(GraphicsContext context)
     {
         if (desc.ShaderBytes is null)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Shader bytecode cannot be null.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "Shader bytecode cannot be null.");
 
             return;
         }
 
         if (desc.ShaderBytes.Length is 0)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Shader bytecode must not be empty.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "Shader bytecode must not be empty.");
         }
 
         if (string.IsNullOrEmpty(desc.EntryPoint))
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Shader entry point must not be null or empty.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "Shader entry point must not be null or empty.");
         }
 
         ValidateDefinedEnum(desc.Stage, "shader stage");
@@ -368,17 +458,23 @@ internal class ResourceValidator(GraphicsContext context)
 
                 if (rasterizerState.DepthBias < 0)
                 {
-                    context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Depth bias must be greater than or equal to zero.");
+                    context.PublishDebugCallback(MessageCategory.System,
+                                                 MessageSeverity.Error,
+                                                 "Depth bias must be greater than or equal to zero.");
                 }
 
                 if (rasterizerState.DepthBiasClamp < 0)
                 {
-                    context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Depth bias clamp must be greater than or equal to zero.");
+                    context.PublishDebugCallback(MessageCategory.System,
+                                                 MessageSeverity.Error,
+                                                 "Depth bias clamp must be greater than or equal to zero.");
                 }
 
                 if (rasterizerState.SlopeScaledDepthBias < 0)
                 {
-                    context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Slope scaled depth bias must be greater than or equal to zero.");
+                    context.PublishDebugCallback(MessageCategory.System,
+                                                 MessageSeverity.Error,
+                                                 "Slope scaled depth bias must be greater than or equal to zero.");
                 }
             }
 
@@ -444,7 +540,9 @@ internal class ResourceValidator(GraphicsContext context)
     {
         if (desc.Shader?.IsDisposed is not false)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Compute pipeline must reference a valid shader that is not disposed.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "Compute pipeline must reference a valid shader that is not disposed.");
         }
 
         ValidateResourceLayouts(desc.ResourceLayouts);
@@ -469,7 +567,9 @@ internal class ResourceValidator(GraphicsContext context)
 
         if (desc.HitGroups is null)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Ray tracing pipeline hit groups cannot be null.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "Ray tracing pipeline hit groups cannot be null.");
         }
         else
         {
@@ -481,7 +581,9 @@ internal class ResourceValidator(GraphicsContext context)
 
                 if (string.IsNullOrEmpty(hitGroup.Name))
                 {
-                    context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Hit group at index {i} must have a non-empty name.");
+                    context.PublishDebugCallback(MessageCategory.System,
+                                                 MessageSeverity.Error,
+                                                 $"Hit group at index {i} must have a non-empty name.");
                 }
             }
 
@@ -489,7 +591,9 @@ internal class ResourceValidator(GraphicsContext context)
 
             if (hitGroupNames.Distinct().Count() != hitGroupNames.Length)
             {
-                context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Ray tracing pipeline hit groups must have unique names. Duplicate names found.");
+                context.PublishDebugCallback(MessageCategory.System,
+                                             MessageSeverity.Error,
+                                             "Ray tracing pipeline hit groups must have unique names. Duplicate names found.");
             }
         }
 
@@ -497,17 +601,23 @@ internal class ResourceValidator(GraphicsContext context)
 
         if (desc.MaxTraceRecursionDepth > 31)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Max trace recursion depth must be less than or equal to 31.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "Max trace recursion depth must be less than or equal to 31.");
         }
 
         if (desc.MaxPayloadSizeInBytes % 4 is not 0)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Max payload size in bytes must be a multiple of 4.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "Max payload size in bytes must be a multiple of 4.");
         }
 
         if (desc.MaxAttributeSizeInBytes % 4 is not 0 or > 32)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Max attribute size in bytes must be a multiple of 4 and less than or equal to 32.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "Max attribute size in bytes must be a multiple of 4 and less than or equal to 32.");
         }
     }
 
@@ -517,44 +627,62 @@ internal class ResourceValidator(GraphicsContext context)
 
         if (surface.Handles is null)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Surface handles cannot be null.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "Surface handles cannot be null.");
 
             return;
         }
 
         if (surface.Type is SurfaceType.Win32 && surface.Handles.Length is not 1)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Win32 surface must have exactly one handle (HWND).");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "Win32 surface must have exactly one handle (HWND).");
         }
         else if (surface.Type is SurfaceType.Wayland && surface.Handles.Length is not 2)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Wayland surface must have exactly two handles (display and surface).");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "Wayland surface must have exactly two handles (display and surface).");
         }
         else if (surface.Type is SurfaceType.Xlib && surface.Handles.Length is not 2)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Xlib surface must have exactly two handles (display and window).");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "Xlib surface must have exactly two handles (display and window).");
         }
         else if (surface.Type is SurfaceType.Android && surface.Handles.Length is not 1)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Android surface must have exactly one handle (native window).");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "Android surface must have exactly one handle (native window).");
         }
         else if (surface.Type is SurfaceType.IOS && surface.Handles.Length is not 1)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "iOS surface must have exactly one handle (view).");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "iOS surface must have exactly one handle (view).");
         }
         else if (surface.Type is SurfaceType.MacOS && surface.Handles.Length is not 1)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "MacOS surface must have exactly one handle (view).");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "MacOS surface must have exactly one handle (view).");
         }
 
         if (surface.Handles.Any(static item => item is 0))
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Surface handles cannot contain zero values.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "Surface handles cannot contain zero values.");
         }
 
         if (surface.Width is 0 || surface.Height is 0)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Surface width and height must be greater than zero.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "Surface width and height must be greater than zero.");
         }
     }
 
@@ -562,16 +690,20 @@ internal class ResourceValidator(GraphicsContext context)
     {
         if (attachment.Target?.IsDisposed is not false)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Attachment '{name}' is invalid. It must reference a valid texture that is not disposed.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         $"Attachment '{name}' is invalid. It must reference a valid texture that is not disposed.");
 
             return;
         }
 
-        ObtainTextureValues(attachment.Target, name, out TextureType type, out uint layers, out uint mipLevels);
+        ObtainTextureValues(attachment.Target, out TextureType type, out uint layers, out uint mipLevels, name);
 
         if (type is not TextureType.Texture2D or TextureType.Texture2DArray)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid texture type for frame buffer attachment '{name}': {type}. Only Texture2D and Texture2DArray are supported.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         $"Invalid texture type for frame buffer attachment '{name}': {type}. Only Texture2D and Texture2DArray are supported.");
         }
 
         ValidateTextureSlice(type, layers, mipLevels, attachment.Slice, name);
@@ -607,7 +739,9 @@ internal class ResourceValidator(GraphicsContext context)
     {
         if (shaders is null)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"{name} cannot be null.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         $"{name} cannot be null.");
 
             return;
         }
@@ -622,7 +756,9 @@ internal class ResourceValidator(GraphicsContext context)
     {
         if (resourceLayouts is null)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Resource layouts cannot be null.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "Resource layouts cannot be null.");
 
             return;
         }
@@ -633,7 +769,9 @@ internal class ResourceValidator(GraphicsContext context)
 
             if (resourceLayout?.IsDisposed is not false)
             {
-                context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Resource layout at index {i} must reference a valid resource layout that is not disposed.");
+                context.PublishDebugCallback(MessageCategory.System,
+                                             MessageSeverity.Error,
+                                             $"Resource layout at index {i} must reference a valid resource layout that is not disposed.");
             }
         }
     }
@@ -642,26 +780,34 @@ internal class ResourceValidator(GraphicsContext context)
     {
         if (output.ColorAttachments is null)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Output color attachments cannot be null.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "Output color attachments cannot be null.");
 
             return;
         }
 
         if (output.ColorAttachments.Length is 0 && output.DepthStencilAttachment is null)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Output must have at least one color attachment or a depth-stencil attachment.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "Output must have at least one color attachment or a depth-stencil attachment.");
 
             return;
         }
 
         if (output.ColorAttachments.Length > 8)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Output cannot have more than 8 color attachments.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         "Output cannot have more than 8 color attachments.");
         }
 
         if (output.DepthStencilAttachment is not null && !depthStencilFormats.Contains(output.DepthStencilAttachment.Value))
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid depth-stencil attachment format: {output.DepthStencilAttachment.Value}. Supported formats are: {string.Join(", ", depthStencilFormats.Select(static item => item.ToString()))}.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         $"Invalid depth-stencil attachment format: {output.DepthStencilAttachment.Value}. Supported formats are: {string.Join(", ", depthStencilFormats.Select(static item => item.ToString()))}.");
         }
     }
 
@@ -670,7 +816,9 @@ internal class ResourceValidator(GraphicsContext context)
     {
         if (!Enum.IsDefined(value))
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid {name}: {value}. Supported values are: {string.Join(", ", Enum.GetNames<TEnum>())}.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         $"Invalid {name}: {value}. Supported values are: {string.Join(", ", Enum.GetNames<TEnum>())}.");
         }
     }
 
@@ -678,13 +826,19 @@ internal class ResourceValidator(GraphicsContext context)
     {
         if (shader?.IsDisposed is not false)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"{name} must reference a valid shader that is not disposed.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         $"{name} must reference a valid shader that is not disposed.");
         }
     }
     #endregion
 
     #region Universal Texture Validation
-    private void ObtainTextureValues(ITexture iTexture, string name, out TextureType type, out uint layers, out uint mipLevels)
+    private void ObtainTextureValues(ITexture iTexture,
+                                     out TextureType type,
+                                     out uint layers,
+                                     out uint mipLevels,
+                                     string name)
     {
         if (iTexture is Texture texture)
         {
@@ -704,39 +858,55 @@ internal class ResourceValidator(GraphicsContext context)
             layers = default;
             mipLevels = default;
 
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid texture type for slice validation in {name}. Expected Texture or TextureView.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         $"Invalid texture type for slice validation in {name}. Expected Texture or TextureView.");
         }
     }
 
-    private void ValidateTextureSlice(TextureType type, uint layers, uint mipLevels, TextureSlice slice, string name)
+    private void ValidateTextureSlice(TextureType type,
+                                      uint layers,
+                                      uint mipLevels,
+                                      TextureSlice slice,
+                                      string name)
     {
         if (type is TextureType.TextureCube or TextureType.TextureCubeArray)
         {
             if (slice.Face >= 6)
             {
-                context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid face index: {slice.Face} for {name} with texture type {type}. It must be less than 6.");
+                context.PublishDebugCallback(MessageCategory.System,
+                                             MessageSeverity.Error,
+                                             $"Invalid face index: {slice.Face} for {name} with texture type {type}. It must be less than 6.");
             }
         }
         else if (slice.Face is not 0)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid face index: {slice.Face} for {name} with texture type {type}. Only TextureCube and TextureCubeArray support multiple faces.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         $"Invalid face index: {slice.Face} for {name} with texture type {type}. Only TextureCube and TextureCubeArray support multiple faces.");
         }
 
         if (arrayTextureTypes.Contains(type))
         {
             if (slice.Layer >= layers)
             {
-                context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid layer index: {slice.Layer} for {name} with texture type {type}. It must be less than the number of layers ({layers}).");
+                context.PublishDebugCallback(MessageCategory.System,
+                                             MessageSeverity.Error,
+                                             $"Invalid layer index: {slice.Layer} for {name} with texture type {type}. It must be less than the number of layers ({layers}).");
             }
         }
         else if (slice.Layer is not 0)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid layer index: {slice.Layer} for {name} with texture type {type}. Only array textures support multiple layers.");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         $"Invalid layer index: {slice.Layer} for {name} with texture type {type}. Only array textures support multiple layers.");
         }
 
         if (slice.MipLevel >= mipLevels)
         {
-            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid mip level: {slice.MipLevel} for {name} with texture type {type}. It must be less than the number of mip levels ({mipLevels}).");
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         $"Invalid mip level: {slice.MipLevel} for {name} with texture type {type}. It must be less than the number of mip levels ({mipLevels}).");
         }
     }
     #endregion

--- a/sources/Zenith.NET/Structs/BufferViewDesc.cs
+++ b/sources/Zenith.NET/Structs/BufferViewDesc.cs
@@ -7,4 +7,6 @@ public record struct BufferViewDesc
     public uint OffsetInBytes;
 
     public uint SizeInBytes;
+
+    public uint StrideInBytes;
 }

--- a/sources/Zenith.NET/Structs/BufferViewDesc.cs
+++ b/sources/Zenith.NET/Structs/BufferViewDesc.cs
@@ -7,6 +7,4 @@ public record struct BufferViewDesc
     public uint OffsetInBytes;
 
     public uint SizeInBytes;
-
-    public BufferUsageFlags? Flags;
 }

--- a/sources/Zenith.NET/Structs/InputElement.cs
+++ b/sources/Zenith.NET/Structs/InputElement.cs
@@ -4,7 +4,7 @@ public record struct InputElement
 {
     public ElementFormat Format;
 
-    public ElementSemanticType Type;
+    public ElementSemantic Semantic;
 
     public uint Index;
 

--- a/sources/Zenith.NET/Structs/InputLayout.cs
+++ b/sources/Zenith.NET/Structs/InputLayout.cs
@@ -10,7 +10,16 @@ public record struct InputLayout
     {
         element.OffsetInBytes = StrideInBytes;
 
-        Elements = [.. Elements, element];
+        if (Elements is null)
+        {
+            Elements = [element];
+        }
+        else
+        {
+            Array.Resize(ref Elements, Elements.Length + 1);
+
+            Elements[^1] = element;
+        }
 
         StrideInBytes += GetFormatSizeInBytes(element.Format);
 

--- a/sources/Zenith.NET/Structs/TextureViewDesc.cs
+++ b/sources/Zenith.NET/Structs/TextureViewDesc.cs
@@ -4,9 +4,11 @@ public record struct TextureViewDesc
 {
     public Texture Texture;
 
-    public uint MipLevel;
-
     public uint FirstLayer;
 
     public uint LayerCount;
+
+    public uint FirstMipLevel;
+
+    public uint MipLevelCount;
 }

--- a/sources/Zenith.NET/Structs/TextureViewDesc.cs
+++ b/sources/Zenith.NET/Structs/TextureViewDesc.cs
@@ -9,6 +9,4 @@ public record struct TextureViewDesc
     public uint FirstLayer;
 
     public uint LayerCount;
-
-    public TextureUsageFlags? Flags;
 }

--- a/sources/Zenith.NET/Texture.cs
+++ b/sources/Zenith.NET/Texture.cs
@@ -11,7 +11,7 @@ public abstract class Texture(GraphicsContext context, TextureDesc desc) : Graph
         CommandBuffer commandBuffer = Context.Copy.CommandBuffer();
 
         commandBuffer.Begin();
-        commandBuffer.UpdateTexture(data, this, slice, offset, extent);
+        commandBuffer.UploadTexture(data, this, slice, offset, extent);
         commandBuffer.End();
         commandBuffer.Submit();
 

--- a/sources/Zenith.NET/Texture.cs
+++ b/sources/Zenith.NET/Texture.cs
@@ -8,11 +8,6 @@ public abstract class Texture(GraphicsContext context, TextureDesc desc) : Graph
 
     public void Upload<T>(ReadOnlySpan<T> data, TextureSlice slice, TextureOffset offset, TextureExtent extent)
     {
-        if (Context.UseDebugLayer)
-        {
-            throw new NotImplementedException("Texture upload validation is not implemented yet.");
-        }
-
         CommandBuffer commandBuffer = Context.Copy.CommandBuffer();
 
         commandBuffer.Begin();

--- a/sources/Zenith.NET/TextureView.cs
+++ b/sources/Zenith.NET/TextureView.cs
@@ -8,16 +8,11 @@ public abstract class TextureView(GraphicsContext context, TextureViewDesc desc)
 
     public void Upload<T>(ReadOnlySpan<T> data, TextureSlice slice, TextureOffset offset, TextureExtent extent)
     {
-        if (Context.UseDebugLayer)
-        {
-            throw new NotImplementedException("Texture subresource upload validation is not implemented yet.");
-        }
-
         slice = new()
         {
             Face = slice.Face,
             Layer = Desc.FirstLayer + slice.Layer,
-            MipLevel = Desc.MipLevel + slice.MipLevel
+            MipLevel = Desc.FirstMipLevel + slice.MipLevel
         };
 
         Desc.Texture.Upload(data, slice, offset, extent);

--- a/sources/Zenith.NET/Validator.cs
+++ b/sources/Zenith.NET/Validator.cs
@@ -1,6 +1,6 @@
 ﻿namespace Zenith.NET;
 
-internal class ResourceValidator(GraphicsContext context)
+internal class Validator(GraphicsContext context)
 {
     private static readonly PixelFormat[] swapChainFormats =
     [

--- a/sources/Zenith.NET/Validator.cs
+++ b/sources/Zenith.NET/Validator.cs
@@ -607,12 +607,7 @@ internal class Validator(GraphicsContext context)
 
     public void ValidateComputePipelineDesc(ComputePipelineDesc desc)
     {
-        if (desc.Shader?.IsDisposed is not false)
-        {
-            context.PublishDebugCallback(MessageCategory.System,
-                                         MessageSeverity.Error,
-                                         "Compute pipeline requires a valid, non-disposed shader.");
-        }
+        ValidateShader(desc.Shader, "Compute shader");
 
         ValidateResourceLayouts(desc.ResourceLayouts);
     }

--- a/sources/Zenith.NET/Validator.cs
+++ b/sources/Zenith.NET/Validator.cs
@@ -401,14 +401,30 @@ internal class Validator(GraphicsContext context)
                                          $"Frame buffer supports up to 8 color targets. Got: {desc.ColorTargets.Length}.");
         }
 
+        PixelFormat? targetFormat = null;
+        uint? targetWidth = null;
+        uint? targetHeight = null;
+
         for (int i = 0; i < desc.ColorTargets.Length; i++)
         {
-            ValidateFrameBufferAttachment(desc.ColorTargets[i], $"color target at index {i}");
+            ValidateFrameBufferAttachment(desc.ColorTargets[i],
+                                          ref targetFormat,
+                                          ref targetWidth,
+                                          ref targetHeight,
+                                          TextureUsageFlags.RenderTarget,
+                                          $"color target at index {i}");
         }
 
         if (desc.DepthStencilTarget is not null)
         {
-            ValidateFrameBufferAttachment(desc.DepthStencilTarget.Value, "depth-stencil target");
+            targetFormat = null;
+
+            ValidateFrameBufferAttachment(desc.DepthStencilTarget.Value,
+                                          ref targetFormat,
+                                          ref targetWidth,
+                                          ref targetHeight,
+                                          TextureUsageFlags.DepthStencil,
+                                          "depth-stencil target");
         }
     }
 
@@ -688,7 +704,12 @@ internal class Validator(GraphicsContext context)
         }
     }
 
-    private void ValidateFrameBufferAttachment(FrameBufferAttachment attachment, string name)
+    private void ValidateFrameBufferAttachment(FrameBufferAttachment attachment,
+                                               ref PixelFormat? targetFormat,
+                                               ref uint? targetWidth,
+                                               ref uint? targetHeight,
+                                               TextureUsageFlags targetFlag,
+                                               string name)
     {
         if (attachment.Target?.IsDisposed is not false)
         {
@@ -699,13 +720,62 @@ internal class Validator(GraphicsContext context)
             return;
         }
 
-        ObtainTextureValues(attachment.Target, out TextureType type, out uint layers, out uint mipLevels, name);
+        ObtainTextureValues(attachment.Target,
+                            out TextureType type,
+                            out PixelFormat format,
+                            out uint width,
+                            out uint height,
+                            out _,
+                            out uint layers,
+                            out uint mipLevels,
+                            out TextureUsageFlags flags,
+                            name);
 
         if (type is not TextureType.Texture2D or TextureType.Texture2DArray)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
                                          $"Frame buffer {name} must use Texture2D or Texture2DArray. Got: {type}.");
+        }
+
+        if (targetFormat.HasValue && targetFormat.Value != format)
+        {
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         $"Frame buffer {name} texture format '{format}' does not match expected format '{targetFormat.Value}'.");
+        }
+        else
+        {
+            targetFormat = format;
+        }
+
+        if (targetWidth.HasValue && targetWidth.Value != width)
+        {
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         $"Frame buffer {name} texture width ({width}) does not match expected width ({targetWidth.Value}).");
+        }
+        else
+        {
+            targetWidth = width;
+        }
+
+        if (targetHeight.HasValue && targetHeight.Value != height)
+        {
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         $"Frame buffer {name} texture height ({height}) does not match expected height ({targetHeight.Value}).");
+        }
+        else
+        {
+            targetHeight = height;
+        }
+
+        if (!flags.HasFlag(targetFlag))
+        {
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         $"Frame buffer {name} texture must have usage flag '{targetFlag}'. Got: {flags}.");
         }
 
         ValidateTextureSlice(type, layers, mipLevels, attachment.Slice, name);
@@ -838,27 +908,47 @@ internal class Validator(GraphicsContext context)
     #region Universal Texture Validation
     private void ObtainTextureValues(ITexture iTexture,
                                      out TextureType type,
+                                     out PixelFormat format,
+                                     out uint width,
+                                     out uint height,
+                                     out uint depth,
                                      out uint layers,
                                      out uint mipLevels,
+                                     out TextureUsageFlags flags,
                                      string name)
     {
         if (iTexture is Texture texture)
         {
             type = texture.Desc.Type;
+            format = texture.Desc.Format;
+            width = texture.Desc.Width;
+            height = texture.Desc.Height;
+            depth = texture.Desc.Depth;
             layers = texture.Desc.Layers;
             mipLevels = texture.Desc.MipLevels;
+            flags = texture.Desc.Flags;
         }
         else if (iTexture is TextureView textureView)
         {
             type = textureView.Desc.Texture.Desc.Type;
+            format = textureView.Desc.Texture.Desc.Format;
+            width = textureView.Desc.Texture.Desc.Width;
+            height = textureView.Desc.Texture.Desc.Height;
+            depth = textureView.Desc.Texture.Desc.Depth;
             layers = textureView.Desc.LayerCount;
             mipLevels = textureView.Desc.MipLevelCount;
+            flags = textureView.Desc.Texture.Desc.Flags;
         }
         else
         {
             type = default;
+            format = default;
+            width = default;
+            height = default;
+            depth = default;
             layers = default;
             mipLevels = default;
+            flags = default;
 
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,

--- a/sources/Zenith.NET/Validator.cs
+++ b/sources/Zenith.NET/Validator.cs
@@ -944,9 +944,7 @@ internal class Validator(GraphicsContext context)
 
         for (int i = 0; i < resourceLayouts.Length; i++)
         {
-            ResourceLayout? resourceLayout = resourceLayouts[i];
-
-            if (resourceLayout?.IsDisposed is not false)
+            if (resourceLayouts[i]?.IsDisposed is not false)
             {
                 context.PublishDebugCallback(MessageCategory.System,
                                              MessageSeverity.Error,

--- a/sources/Zenith.NET/Validator.cs
+++ b/sources/Zenith.NET/Validator.cs
@@ -593,11 +593,28 @@ internal class Validator(GraphicsContext context)
             ValidateShader(shaders.Pixel, "Pixel shader");
         }
 
-        if (desc.InputLayouts is null || desc.InputLayouts.Length is 0)
+        // InputLayouts
         {
-            context.PublishDebugCallback(MessageCategory.System,
-                                         MessageSeverity.Error,
-                                         "Graphics pipeline must specify at least 1 input layout.");
+            if (desc.InputLayouts is null)
+            {
+                context.PublishDebugCallback(MessageCategory.System,
+                                             MessageSeverity.Error,
+                                             "Input layouts cannot be null.");
+
+                return;
+            }
+
+            if (desc.InputLayouts.Length is 0)
+            {
+                context.PublishDebugCallback(MessageCategory.System,
+                                             MessageSeverity.Error,
+                                             "Graphics pipeline must have at least 1 input layout.");
+            }
+
+            for (int i = 0; i < desc.InputLayouts.Length; i++)
+            {
+                ValidateInputLayout(desc.InputLayouts[i], $"input layout at index {i}");
+            }
         }
 
         ValidateResourceLayouts(desc.ResourceLayouts);
@@ -876,6 +893,41 @@ internal class Validator(GraphicsContext context)
         for (int i = 0; i < shaders.Length; i++)
         {
             ValidateShader(shaders[i], $"{name} at index {i}");
+        }
+    }
+
+    private void ValidateInputLayout(InputLayout inputLayout, string name)
+    {
+        if (inputLayout.Elements is null)
+        {
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         $"{name} elements cannot be null.");
+
+            return;
+        }
+
+        if (inputLayout.Elements.Length is 0)
+        {
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         $"{name} must contain at least 1 element.");
+        }
+
+        for (int i = 0; i < inputLayout.Elements.Length; i++)
+        {
+            InputElement inputElement = inputLayout.Elements[i];
+
+            ValidateDefinedEnum(inputElement.Format, $"input element format at index {i}");
+
+            ValidateDefinedEnum(inputElement.Semantic, $"input element semantic at index {i}");
+        }
+
+        if (inputLayout.StrideInBytes is 0)
+        {
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         $"{name} stride must be greater than 0.");
         }
     }
 

--- a/sources/Zenith.NET/Validator.cs
+++ b/sources/Zenith.NET/Validator.cs
@@ -341,7 +341,11 @@ internal class Validator(GraphicsContext context)
                     }
                     else
                     {
-                        ObtainBufferValues((IBuffer)resource, out _, out _, out BufferUsageFlags flags, $"resource at index {i}");
+                        ObtainBufferValues((IBuffer)resource,
+                                           out _,
+                                           out _,
+                                           out BufferUsageFlags flags,
+                                           $"resource at index {i}");
 
                         BufferUsageFlags requestFlag = types[i] switch
                         {
@@ -370,6 +374,7 @@ internal class Validator(GraphicsContext context)
                     else
                     {
                         ObtainTextureValues((ITexture)resource,
+                                            out _,
                                             out _,
                                             out _,
                                             out _,
@@ -447,28 +452,28 @@ internal class Validator(GraphicsContext context)
                                          $"Frame buffer supports up to 8 color targets. Got: {desc.ColorTargets.Length}.");
         }
 
-        PixelFormat? targetFormat = null;
         uint? targetWidth = null;
         uint? targetHeight = null;
+        SampleCount? sampleCount = null;
 
         for (int i = 0; i < desc.ColorTargets.Length; i++)
         {
             ValidateFrameBufferAttachment(desc.ColorTargets[i],
-                                          ref targetFormat,
+                                          null,
                                           ref targetWidth,
                                           ref targetHeight,
+                                          ref sampleCount,
                                           TextureUsageFlags.RenderTarget,
                                           $"color target at index {i}");
         }
 
         if (desc.DepthStencilTarget is not null)
         {
-            targetFormat = null;
-
             ValidateFrameBufferAttachment(desc.DepthStencilTarget.Value,
-                                          ref targetFormat,
+                                          depthStencilFormats,
                                           ref targetWidth,
                                           ref targetHeight,
+                                          ref sampleCount,
                                           TextureUsageFlags.DepthStencil,
                                           "depth-stencil target");
         }
@@ -751,9 +756,10 @@ internal class Validator(GraphicsContext context)
     }
 
     private void ValidateFrameBufferAttachment(FrameBufferAttachment attachment,
-                                               ref PixelFormat? targetFormat,
+                                               PixelFormat[]? targetFormats,
                                                ref uint? targetWidth,
                                                ref uint? targetHeight,
+                                               ref SampleCount? targetSampleCount,
                                                TextureUsageFlags targetFlag,
                                                string name)
     {
@@ -774,6 +780,7 @@ internal class Validator(GraphicsContext context)
                             out _,
                             out uint layers,
                             out uint mipLevels,
+                            out SampleCount sampleCount,
                             out TextureUsageFlags flags,
                             name);
 
@@ -784,15 +791,11 @@ internal class Validator(GraphicsContext context)
                                          $"Frame buffer {name} must use Texture2D or Texture2DArray. Got: {type}.");
         }
 
-        if (targetFormat.HasValue && targetFormat.Value != format)
+        if (targetFormats?.Contains(format) is false)
         {
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
-                                         $"Frame buffer {name} texture format '{format}' does not match expected format '{targetFormat.Value}'.");
-        }
-        else
-        {
-            targetFormat = format;
+                                         $"Frame buffer {name} texture format '{format}' is not supported. Valid formats: {string.Join(", ", targetFormats.Select(static item => item.ToString()))}.");
         }
 
         if (targetWidth.HasValue && targetWidth.Value != width)
@@ -815,6 +818,17 @@ internal class Validator(GraphicsContext context)
         else
         {
             targetHeight = height;
+        }
+
+        if (targetSampleCount.HasValue && targetSampleCount.Value != sampleCount)
+        {
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         $"Frame buffer {name} texture sample count ({sampleCount}) does not match expected sample count ({targetSampleCount.Value}).");
+        }
+        else
+        {
+            targetSampleCount = sampleCount;
         }
 
         if (!flags.HasFlag(targetFlag))
@@ -992,6 +1006,7 @@ internal class Validator(GraphicsContext context)
                                      out uint depth,
                                      out uint layers,
                                      out uint mipLevels,
+                                     out SampleCount sampleCount,
                                      out TextureUsageFlags flags,
                                      string name)
     {
@@ -1004,6 +1019,7 @@ internal class Validator(GraphicsContext context)
             depth = texture.Desc.Depth;
             layers = texture.Desc.Layers;
             mipLevels = texture.Desc.MipLevels;
+            sampleCount = texture.Desc.SampleCount;
             flags = texture.Desc.Flags;
         }
         else if (iTexture is TextureView textureView)
@@ -1015,6 +1031,7 @@ internal class Validator(GraphicsContext context)
             depth = textureView.Desc.Texture.Desc.Depth;
             layers = textureView.Desc.LayerCount;
             mipLevels = textureView.Desc.MipLevelCount;
+            sampleCount = textureView.Desc.Texture.Desc.SampleCount;
             flags = textureView.Desc.Texture.Desc.Flags;
         }
         else
@@ -1026,6 +1043,7 @@ internal class Validator(GraphicsContext context)
             depth = default;
             layers = default;
             mipLevels = default;
+            sampleCount = default;
             flags = default;
 
             context.PublishDebugCallback(MessageCategory.System,

--- a/sources/Zenith.NET/Validator.cs
+++ b/sources/Zenith.NET/Validator.cs
@@ -1,0 +1,86 @@
+﻿namespace Zenith.NET;
+
+internal class Validator(GraphicsContext context)
+{
+    private static readonly PixelFormat[] swapChainFormats =
+    [
+        PixelFormat.R8G8B8A8UNorm,
+        PixelFormat.R8G8B8A8UNormSRgb,
+        PixelFormat.R16G16B16A16Float,
+        PixelFormat.B8G8R8A8UNorm,
+        PixelFormat.B8G8R8A8UNormSRgb
+    ];
+
+    private static readonly PixelFormat[] depthStencilFormats =
+    [
+        PixelFormat.D24UNormS8UInt,
+        PixelFormat.D32FloatS8UInt
+    ];
+
+    public void ValidateSwapChainDesc(SwapChainDesc desc)
+    {
+        ValidateSurface(desc.Surface);
+
+        if (!swapChainFormats.Contains(desc.ColorTargetFormat))
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid color target format: {desc.ColorTargetFormat}. Supported formats are: {string.Join(", ", swapChainFormats.Select(f => f.ToString()))}.");
+        }
+
+        if (desc.DepthStencilTargetFormat.HasValue && !depthStencilFormats.Contains(desc.DepthStencilTargetFormat.Value))
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid depth-stencil target format: {desc.DepthStencilTargetFormat.Value}. Supported formats are: {string.Join(", ", depthStencilFormats.Select(f => f.ToString()))}.");
+        }
+    }
+
+    private void ValidateSurface(Surface surface)
+    {
+        if (!Enum.IsDefined(surface.Type))
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, $"Invalid surface type: {surface.Type}. Supported types are: {string.Join(", ", Enum.GetNames<SurfaceType>())}.");
+
+            return;
+        }
+
+        if (surface.Handles is null)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Surface handles cannot be null.");
+
+            return;
+        }
+
+        if (surface.Type is SurfaceType.Win32 && surface.Handles.Length is not 1)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Win32 surface must have exactly one handle (HWND).");
+        }
+        else if (surface.Type is SurfaceType.Wayland && surface.Handles.Length is not 2)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Wayland surface must have exactly two handles (display and surface).");
+        }
+        else if (surface.Type is SurfaceType.Xlib && surface.Handles.Length is not 2)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Xlib surface must have exactly two handles (display and window).");
+        }
+        else if (surface.Type is SurfaceType.Android && surface.Handles.Length is not 1)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Android surface must have exactly one handle (native window).");
+        }
+        else if (surface.Type is SurfaceType.IOS && surface.Handles.Length is not 1)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "iOS surface must have exactly one handle (view).");
+        }
+        else if (surface.Type is SurfaceType.MacOS && surface.Handles.Length is not 1)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "MacOS surface must have exactly one handle (view).");
+        }
+
+        if (surface.Handles.Any(static item => item is 0))
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Surface handles cannot contain zero values.");
+        }
+
+        if (surface.Width is 0 || surface.Height is 0)
+        {
+            context.PublishDebugCallback(MessageCategory.System, MessageSeverity.Error, "Surface width and height must be greater than zero.");
+        }
+    }
+}

--- a/sources/Zenith.NET/Validator.cs
+++ b/sources/Zenith.NET/Validator.cs
@@ -339,6 +339,25 @@ internal class Validator(GraphicsContext context)
                                                      MessageSeverity.Error,
                                                      $"Resource at index {i} must be a buffer or buffer view for resource type '{types[i]}'.");
                     }
+                    else
+                    {
+                        ObtainBufferValues((IBuffer)resource, out _, out _, out BufferUsageFlags flags, $"resource at index {i}");
+
+                        BufferUsageFlags requestFlag = types[i] switch
+                        {
+                            ResourceType.ConstantBuffer => BufferUsageFlags.Constant,
+                            ResourceType.StructuredBuffer => BufferUsageFlags.ShaderResource,
+                            ResourceType.StructuredBufferReadWrite => BufferUsageFlags.UnorderedAccess,
+                            _ => BufferUsageFlags.None
+                        };
+
+                        if (!flags.HasFlag(requestFlag))
+                        {
+                            context.PublishDebugCallback(MessageCategory.System,
+                                                         MessageSeverity.Warning,
+                                                         $"Resource at index {i} must have usage flag '{requestFlag}' for resource type '{types[i]}'. Got: {flags}.");
+                        }
+                    }
                     break;
                 case ResourceType.Texture:
                 case ResourceType.TextureReadWrite:
@@ -347,6 +366,33 @@ internal class Validator(GraphicsContext context)
                         context.PublishDebugCallback(MessageCategory.System,
                                                      MessageSeverity.Error,
                                                      $"Resource at index {i} must be a texture or texture view for resource type '{types[i]}'.");
+                    }
+                    else
+                    {
+                        ObtainTextureValues((ITexture)resource,
+                                            out _,
+                                            out _,
+                                            out _,
+                                            out _,
+                                            out _,
+                                            out _,
+                                            out _,
+                                            out TextureUsageFlags flags,
+                                            $"resource at index {i}");
+
+                        TextureUsageFlags requestFlag = types[i] switch
+                        {
+                            ResourceType.Texture => TextureUsageFlags.ShaderResource,
+                            ResourceType.TextureReadWrite => TextureUsageFlags.UnorderedAccess,
+                            _ => TextureUsageFlags.None
+                        };
+
+                        if (!flags.HasFlag(requestFlag))
+                        {
+                            context.PublishDebugCallback(MessageCategory.System,
+                                                         MessageSeverity.Warning,
+                                                         $"Resource at index {i} must have usage flag '{requestFlag}' for resource type '{types[i]}'. Got: {flags}.");
+                        }
                     }
                     break;
                 case ResourceType.Sampler:
@@ -901,6 +947,38 @@ internal class Validator(GraphicsContext context)
             context.PublishDebugCallback(MessageCategory.System,
                                          MessageSeverity.Error,
                                          $"{name} must be valid and non-disposed.");
+        }
+    }
+    #endregion
+
+    #region Universal Buffer Validation
+    private void ObtainBufferValues(IBuffer iBuffer,
+                                    out uint sizeInBytes,
+                                    out uint strideInBytes,
+                                    out BufferUsageFlags flags,
+                                    string name)
+    {
+        if (iBuffer is Buffer buffer)
+        {
+            sizeInBytes = buffer.Desc.SizeInBytes;
+            strideInBytes = buffer.Desc.StrideInBytes;
+            flags = buffer.Desc.Flags;
+        }
+        else if (iBuffer is BufferView bufferView)
+        {
+            sizeInBytes = bufferView.Desc.SizeInBytes;
+            strideInBytes = bufferView.Desc.StrideInBytes;
+            flags = bufferView.Desc.Buffer.Desc.Flags;
+        }
+        else
+        {
+            sizeInBytes = default;
+            strideInBytes = default;
+            flags = default;
+
+            context.PublishDebugCallback(MessageCategory.System,
+                                         MessageSeverity.Error,
+                                         $"Cannot validate buffer slice for {name}: expected Buffer or BufferView.");
         }
     }
     #endregion


### PR DESCRIPTION
## Description

This PR introduces a comprehensive resource validation layer that provides runtime validation for all graphics resource descriptors and API usage.

## What's New

### 🛡️ Resource Validation
- Added `Validator` class that validates all resource descriptors before creation
- Comprehensive validation for:
  - SwapChain configurations
  - Buffer and BufferView descriptors
  - Texture and TextureView descriptors
  - Sampler states
  - Resource layouts and sets
  - FrameBuffer attachments
  - Shader modules
  - Pipeline states (Graphics, Compute, Ray Tracing)

### 🔍 Validation Features
- **Format validation**: Ensures only supported formats are used for swap chains and depth-stencil targets
- **Bounds checking**: Validates offsets, sizes, and ranges for buffer/texture operations
- **Resource state validation**: Checks for disposed resources and null references
- **Compatibility validation**: Ensures resource types match their intended usage
- **API compliance**: Validates against graphics API limitations (e.g., max 8 render targets)

### 📊 Debug Integration
- Validation messages are published through `GraphicsContext.PublishDebugCallback`
- Three severity levels: Error, Warning, Info
- Clear, actionable error messages with context