### PR TITLE
Prepare release v0.0.4

### DIFF
--- a/documents/docfx.json
+++ b/documents/docfx.json
@@ -44,7 +44,7 @@
     "template": [
       "default",
       "modern",
-      "template"
+      "templates"
     ],
     "globalMetadata": {
       "_appName": "Zenith.NET",

--- a/documents/docfx.json
+++ b/documents/docfx.json
@@ -47,8 +47,7 @@
       "templates"
     ],
     "globalMetadata": {
-      "_appName": "Zenith.NET",
-      "_appTitle": "Zenith.NET Documentation",
+      "_appTitle": "Zenith.NET",
       "_appLogoPath": "images/Zenith.NET.svg",
       "_appFaviconPath": "images/Zenith.NET.png",
       "_enableSearch": true,

--- a/documents/index.md
+++ b/documents/index.md
@@ -1,3 +1,7 @@
-﻿# Zenith.NET
+﻿---
+title: Zenith.NET - Unified Cross-Platform GPU Programming Interface
+---
+
+# Zenith.NET
 
 Welcome to the Zenith.NET documentation.

--- a/documents/template/public/main.css
+++ b/documents/template/public/main.css
@@ -1,4 +1,0 @@
-﻿#logo {
-  max-height: 32px;
-  width: auto;
-}

--- a/documents/templates/public/main.css
+++ b/documents/templates/public/main.css
@@ -1,10 +1,3 @@
-﻿.navbar-brand {
-  justify-content: center;
-  margin-right: 32px;
-}
-
-#logo {
-  width: auto;
-  max-height: 50px;
-  margin-right: 8px;
+﻿#logo {
+  height: 50px;
 }

--- a/documents/templates/public/main.css
+++ b/documents/templates/public/main.css
@@ -1,0 +1,10 @@
+﻿.navbar-brand {
+  justify-content: center;
+  margin-right: 32px;
+}
+
+#logo {
+  width: auto;
+  max-height: 50px;
+  margin-right: 8px;
+}

--- a/documents/templates/public/main.js
+++ b/documents/templates/public/main.js
@@ -1,0 +1,10 @@
+﻿export default {
+  defaultTheme: 'auto',
+  iconLinks: [
+    {
+      icon: 'github',
+      href: 'https://github.com/qian-o/Zenith.NET',
+      title: 'GitHub'
+    }
+  ]
+}

--- a/sources/NuGet.Packaging.props
+++ b/sources/NuGet.Packaging.props
@@ -7,7 +7,7 @@
         <PackageOutputPath>$(MSBuildThisFileDirectory)..\.nuget</PackageOutputPath>
 
         <!-- Package Metadata -->
-        <Version>0.0.3</Version>
+        <Version>0.0.4</Version>
         <Authors>qian-o</Authors>
         <Copyright>Copyright (c) 2026 qian-o</Copyright>
         <Description>Zenith.NET is a modern, cross-platform graphics and compute library for .NET. It provides a unified GPU programming interface supporting DirectX12, Metal, and Vulkan backends.</Description>


### PR DESCRIPTION
This pull request updates the documentation site and NuGet package metadata for Zenith.NET. The main changes include improvements to the documentation site's appearance and structure, updates to metadata, and the addition of a configuration file for the documentation template.

Documentation site updates:

* Changed the documentation site's template reference in `docfx.json` from `template` to `templates`, updated the app title, and removed the `_appName` field.
* Added a YAML front matter block with a custom title to `index.md` for better metadata and search engine optimization.
* Moved the main CSS file from `documents/template/public/main.css` to `documents/templates/public/main.css`, and updated the logo styling to increase its height to 50px. [[1]](diffhunk://#diff-3a813b8975d4e3fdbf52ae5905717ebdaf211216365df0689f5eb2f1998ee9abL1-L4) [[2]](diffhunk://#diff-ada3ed194712d69b5fb97c8d3938b6429de0871621d40814b66eb0a06b987432R1-R3)
* Added a new `main.js` configuration file for the documentation template, specifying the default theme and adding a GitHub icon link.

NuGet package metadata update:

* Bumped the NuGet package version from `0.0.3` to `0.0.4` in `NuGet.Packaging.props`.