### PR TITLE
fix(docs): correct compute shader output texture format to B8G8R8A8UNorm

### DIFF
--- a/documents/tutorials/advanced/mesh-shading.md
+++ b/documents/tutorials/advanced/mesh-shading.md
@@ -66,6 +66,8 @@ namespace ZenithTutorials.Renderers;
 
 internal unsafe class MeshShadingRenderer : IRenderer
 {
+    private const uint MaxPrimitives = 126;
+
     private const string ShaderSource = """
         static const uint MaxVertices = 64;
         static const uint MaxPrimitives = 126;
@@ -302,7 +304,10 @@ internal unsafe class MeshShadingRenderer : IRenderer
             Pixel = pixelShader,
             ResourceLayout = resourceLayout,
             PrimitiveTopology = PrimitiveTopology.TriangleList,
-            Output = App.SwapChain.FrameBuffer.Output
+            Output = App.SwapChain.FrameBuffer.Output,
+            MeshThreadGroupSizeX = MaxPrimitives,
+            MeshThreadGroupSizeY = 1,
+            MeshThreadGroupSizeZ = 1
         });
     }
 
@@ -494,14 +499,25 @@ Unlike traditional `Draw` calls, mesh shading uses `DispatchMesh(X, Y, Z)` to la
 pipeline = App.Context.CreateMeshShadingPipeline(new()
 {
     RenderStates = new() { ... },
-    Amplification = null,           // Optional amplification shader
-    Mesh = meshShader,              // Required
-    Pixel = pixelShader,            // Required
+    Amplification = null,
+    Mesh = meshShader,
+    Pixel = pixelShader,
     ResourceLayout = resourceLayout,
     PrimitiveTopology = PrimitiveTopology.TriangleList,
-    Output = App.SwapChain.FrameBuffer.Output
+    Output = App.SwapChain.FrameBuffer.Output,
+    MeshThreadGroupSizeX = MaxPrimitives,
+    MeshThreadGroupSizeY = 1,
+    MeshThreadGroupSizeZ = 1
 });
 ```
+
+The `MeshShadingPipelineDesc` requires:
+- `Amplification` - The compiled amplification shader (optional)
+- `Mesh` - The compiled mesh shader
+- `Pixel` - The compiled pixel shader
+- `ResourceLayout` - Resource bindings (same as graphics pipelines)
+- `ObjectThreadGroupSizeX/Y/Z` - Must match `[numthreads()]` in the amplification shader (if used)
+- `MeshThreadGroupSizeX/Y/Z` - Must match `[numthreads()]` in the mesh shader
 
 ## Amplification Shader (Optional)
 

--- a/documents/tutorials/intermediate/compute-shader.md
+++ b/documents/tutorials/intermediate/compute-shader.md
@@ -19,7 +19,7 @@ Create a new file `Renderers/ComputeShaderRenderer.cs`:
 ```csharp
 namespace ZenithTutorials.Renderers;
 
-internal unsafe class ComputeShaderRenderer : IRenderer
+internal class ComputeShaderRenderer : IRenderer
 {
     private const uint ThreadGroupSize = 16;
 

--- a/documents/tutorials/intermediate/compute-shader.md
+++ b/documents/tutorials/intermediate/compute-shader.md
@@ -65,7 +65,7 @@ internal unsafe class ComputeShaderRenderer : IRenderer
         outputTexture = App.Context.CreateTexture(new()
         {
             Type = TextureType.Texture2D,
-            Format = PixelFormat.R8G8B8A8UNorm,
+            Format = PixelFormat.B8G8R8A8UNorm,
             Width = inputTexture.Desc.Width,
             Height = inputTexture.Desc.Height,
             Depth = 1,
@@ -226,7 +226,7 @@ Key elements:
 outputTexture = App.Context.CreateTexture(new()
 {
     Type = TextureType.Texture2D,
-    Format = PixelFormat.R8G8B8A8UNorm,
+    Format = PixelFormat.B8G8R8A8UNorm,
     Width = inputTexture.Desc.Width,
     Height = inputTexture.Desc.Height,
     Depth = 1,

--- a/sources/Zenith.NET.Vulkan/VKSwapChainFrameBuffer.cs
+++ b/sources/Zenith.NET.Vulkan/VKSwapChainFrameBuffer.cs
@@ -54,6 +54,8 @@ internal unsafe class VKSwapChainFrameBuffer(VKGraphicsContext context, VKSwapCh
             colorTargets = new VKTexture[swapchainImageCount];
             frameBuffers = new VKFrameBuffer[swapchainImageCount];
 
+            CommandBuffer commandBuffer = context.Graphics.CommandBuffer();
+
             for (uint i = 0; i < swapchainImageCount; i++)
             {
                 frameBuffers[i] = new(context, new()
@@ -61,7 +63,11 @@ internal unsafe class VKSwapChainFrameBuffer(VKGraphicsContext context, VKSwapCh
                     ColorAttachments = [new() { Target = colorTargets[i] = new(context, colorTargetDesc, swapchainImages[i]) }],
                     DepthStencilAttachment = depthStencilTarget is not null ? new() { Target = depthStencilTarget } : null
                 });
+
+                colorTargets[i].TransitionLayout(commandBuffer.Vulkan(), default, ImageLayout.PresentSrcKhr);
             }
+
+            commandBuffer.Submit(true);
         }
         else if (swapChain.Desc.Surface.Type is SurfaceType.D3D11Interop)
         {


### PR DESCRIPTION
This pull request updates the mesh shading and compute shader tutorials, as well as the Vulkan swap chain framebuffer logic, to improve clarity, correctness, and Vulkan image layout handling. The most important changes are summarized below:

**Mesh Shading Tutorial Improvements:**

* Added a `MaxPrimitives` constant to `MeshShadingRenderer` and used it to set `MeshThreadGroupSizeX` in the mesh shading pipeline configuration, ensuring consistency between shader code and pipeline setup. [[1]](diffhunk://#diff-a9cd7a7eca16e7027e8268cd6895a91bdd1ddc805c75aad5d74d9a9167e815c1R69-R70) [[2]](diffhunk://#diff-a9cd7a7eca16e7027e8268cd6895a91bdd1ddc805c75aad5d74d9a9167e815c1L305-R310)
* Updated documentation to clarify the required fields for `MeshShadingPipelineDesc`, including the need for `MeshThreadGroupSizeX/Y/Z` to match the mesh shader's `[numthreads()]` attribute.

**Compute Shader Tutorial Correction:**

* Changed the output texture format from `PixelFormat.R8G8B8A8UNorm` to `PixelFormat.B8G8R8A8UNorm` to match expected output and likely hardware requirements. [[1]](diffhunk://#diff-8663952694809b92bc06f308e8aeb4a17179b2bee13c69315e1745168df9d43eL68-R68) [[2]](diffhunk://#diff-8663952694809b92bc06f308e8aeb4a17179b2bee13c69315e1745168df9d43eL229-R229)

**Vulkan Swap Chain Framebuffer Handling:**

* Added explicit Vulkan image layout transitions to `ImageLayout.PresentSrcKhr` for color targets using a command buffer, and ensured the command buffer is submitted after creating framebuffers, improving correctness and compatibility with Vulkan presentation.